### PR TITLE
Added transformation for updating set calls with object and boolean

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -36,6 +36,30 @@
   {
     "copy": [
       {
+        "input": "can-define-map-set-to-update/can-define-map-set-to-update.js",
+        "outputPath": "can-define-map-set-to-update/can-define-map-set-to-update.js",
+        "type": "transform"
+      },
+      {
+        "input": "can-define-map-set-to-update/test-input.js",
+        "outputPath": "can-define-map-set-to-update/can-define-map-set-to-update-test-input.js",
+        "type": "fixture"
+      },
+      {
+        "input": "can-define-map-set-to-update/test-output.js",
+        "outputPath": "can-define-map-set-to-update/can-define-map-set-to-update-test-output.js",
+        "type": "fixture"
+      },
+      {
+        "input": "can-define-map-set-to-update/can-define-map-set-to-update-test.js",
+        "outputPath": "can-define-map-set-to-update/can-define-map-set-to-update-test.js",
+        "type": "test"
+      }
+    ]
+  },
+  {
+    "copy": [
+      {
         "input": "can-extend/can-extend.js",
         "outputPath": "can-extend/can-extend.js",
         "type": "transform"

--- a/lib/transforms/can-define-map-set-to-update/can-define-map-set-to-update-test.js
+++ b/lib/transforms/can-define-map-set-to-update/can-define-map-set-to-update-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('mocha');
+var utils = require('../../../test/utils');
+var transforms = require('../../../');
+
+var toTest = transforms.filter(function (transform) {
+  return transform.name === 'can-define-map-set-to-update/can-define-map-set-to-update.js';
+})[0];
+
+describe('can-define-map-set-to-update', function () {
+
+  it('replaces all references', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-test-input.js');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-test-output.js');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/lib/transforms/can-define-map-set-to-update/can-define-map-set-to-update.js
+++ b/lib/transforms/can-define-map-set-to-update/can-define-map-set-to-update.js
@@ -1,0 +1,42 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = transformer;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function transformer(file, api, options) {
+  var debug = (0, _debug2.default)('can-migrate:can-define-map-set-to-update:' + file.path);
+  var j = api.jscodeshift;
+  var printOptions = options.printOptions || {};
+  var root = j(file.source);
+  var setCalls = root.find(j.CallExpression, {
+    callee: {
+      property: {
+        name: 'set'
+      }
+    }
+  });
+
+  setCalls.forEach(function (statement) {
+    console.log(statement.node.arguments);
+    if (statement.node.arguments.length === 2) {
+      var firstArg = statement.node.arguments[0];
+      var secondArg = statement.node.arguments[1];
+
+      if (firstArg.type === 'ObjectExpression' && typeof secondArg.rawValue === 'boolean') {
+        debug('Replacing .set with .update from .set');
+        statement.node.callee.property.name = 'update';
+        statement.node.arguments.splice(-1);
+      }
+    }
+  });
+  return root.toSource(printOptions);
+} // This is a generated file, see src/templates/can-extend/can-extend.js
+module.exports = exports['default'];

--- a/src/templates/can-define-map-set-to-update/can-define-map-set-to-update-test.js
+++ b/src/templates/can-define-map-set-to-update/can-define-map-set-to-update-test.js
@@ -1,0 +1,19 @@
+require('mocha');
+const utils = require('../../../test/utils');
+const transforms = require('../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define-map-set-to-update/can-define-map-set-to-update.js';
+})[0];
+
+describe('can-define-map-set-to-update', function() {
+
+  it('replaces all references', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-test-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-test-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+
+});

--- a/src/templates/can-define-map-set-to-update/can-define-map-set-to-update.js
+++ b/src/templates/can-define-map-set-to-update/can-define-map-set-to-update.js
@@ -15,7 +15,6 @@ export default function transformer(file, api, options) {
   });
 
   setCalls.forEach((statement) => {
-    console.log(statement.node.arguments);
     if(statement.node.arguments.length === 2) {
       const firstArg = statement.node.arguments[0];
       const secondArg = statement.node.arguments[1];

--- a/src/templates/can-define-map-set-to-update/can-define-map-set-to-update.js
+++ b/src/templates/can-define-map-set-to-update/can-define-map-set-to-update.js
@@ -1,0 +1,31 @@
+// This is a generated file, see src/templates/can-extend/can-extend.js
+import makeDebug from 'debug';
+
+export default function transformer(file, api, options) {
+  const debug = makeDebug(`can-migrate:can-define-map-set-to-update:${file.path}`);
+  const j = api.jscodeshift;
+  const printOptions = options.printOptions || {};
+  const root = j(file.source);
+  var setCalls = root.find(j.CallExpression, {
+    callee: {
+      property: {
+          name: 'set'
+      }
+    }
+  });
+
+  setCalls.forEach((statement) => {
+    console.log(statement.node.arguments);
+    if(statement.node.arguments.length === 2) {
+      const firstArg = statement.node.arguments[0];
+      const secondArg = statement.node.arguments[1];
+
+      if(firstArg.type === 'ObjectExpression' && typeof(secondArg.rawValue) === 'boolean'){
+        debug(`Replacing .set with .update from .set`);
+        statement.node.callee.property.name = 'update';
+        statement.node.arguments.splice(-1);
+      }
+    }
+  });
+  return root.toSource(printOptions);
+}

--- a/src/templates/can-define-map-set-to-update/test-input.js
+++ b/src/templates/can-define-map-set-to-update/test-input.js
@@ -1,0 +1,1 @@
+map.set( { a: 'b' }, true);

--- a/src/templates/can-define-map-set-to-update/test-output.js
+++ b/src/templates/can-define-map-set-to-update/test-output.js
@@ -1,0 +1,1 @@
+map.update({ a: 'b' });

--- a/src/transforms/can-define-map-set-to-update/can-define-map-set-to-update-test.js
+++ b/src/transforms/can-define-map-set-to-update/can-define-map-set-to-update-test.js
@@ -1,0 +1,19 @@
+require('mocha');
+const utils = require('../../../test/utils');
+const transforms = require('../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define-map-set-to-update/can-define-map-set-to-update.js';
+})[0];
+
+describe('can-define-map-set-to-update', function() {
+
+  it('replaces all references', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-test-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-test-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+
+});

--- a/src/transforms/can-define-map-set-to-update/can-define-map-set-to-update.js
+++ b/src/transforms/can-define-map-set-to-update/can-define-map-set-to-update.js
@@ -1,0 +1,31 @@
+// This is a generated file, see src/templates/can-extend/can-extend.js
+import makeDebug from 'debug';
+
+export default function transformer(file, api, options) {
+  const debug = makeDebug(`can-migrate:can-define-map-set-to-update:${file.path}`);
+  const j = api.jscodeshift;
+  const printOptions = options.printOptions || {};
+  const root = j(file.source);
+  var setCalls = root.find(j.CallExpression, {
+    callee: {
+      property: {
+          name: 'set'
+      }
+    }
+  });
+
+  setCalls.forEach((statement) => {
+    console.log(statement.node.arguments);
+    if(statement.node.arguments.length === 2) {
+      const firstArg = statement.node.arguments[0];
+      const secondArg = statement.node.arguments[1];
+
+      if(firstArg.type === 'ObjectExpression' && typeof(secondArg.rawValue) === 'boolean'){
+        debug(`Replacing .set with .update from .set`);
+        statement.node.callee.property.name = 'update';
+        statement.node.arguments.splice(-1);
+      }
+    }
+  });
+  return root.toSource(printOptions);
+}

--- a/test/fixtures/can-define-map-set-to-update/can-define-map-set-to-update-test-input.js
+++ b/test/fixtures/can-define-map-set-to-update/can-define-map-set-to-update-test-input.js
@@ -1,0 +1,1 @@
+map.set( { a: 'b' }, true);

--- a/test/fixtures/can-define-map-set-to-update/can-define-map-set-to-update-test-output.js
+++ b/test/fixtures/can-define-map-set-to-update/can-define-map-set-to-update-test-output.js
@@ -1,0 +1,1 @@
+map.update({ a: 'b' });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 require('../lib/transforms/can-component-rename/can-component-rename-test.js');
+require('../lib/transforms/can-define-map-set-to-update/can-define-map-set-to-update-test.js');
 require('../lib/transforms/can-extend/can-extend-test.js');
 require('../lib/transforms/can-data/can-data-test.js');
 require('../lib/transforms/can-component/import-test.js');


### PR DESCRIPTION
This codemod adds the ability to migrate all calls `.set({}, true)` on DefineMap and DefineList to `update({})`.

See issue canjs/can-define#245 for details