### PR TITLE
adding codemod for converting to new can-stache-bindings syntaxes

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -32,6 +32,96 @@
         "type": "test"
       }
     ]
+  }, {
+    "copy": [
+      {
+        "input": "can-stache-bindings/colon-bindings.js",
+        "outputPath": "can-stache-bindings/colon-bindings.js",
+        "type": "transform"
+      },
+
+      {
+        "input": "can-stache-bindings/input.js",
+        "outputPath": "can-stache-bindings/colon-bindings-input.js",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output.js",
+        "outputPath": "can-stache-bindings/colon-bindings-output.js",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output-implicit.js",
+        "outputPath": "can-stache-bindings/colon-bindings-output-implicit.js",
+        "type": "fixture"
+      },
+
+      {
+        "input": "can-stache-bindings/input.stache",
+        "outputPath": "can-stache-bindings/colon-bindings-input.stache",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output.stache",
+        "outputPath": "can-stache-bindings/colon-bindings-output.stache",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output-implicit.stache",
+        "outputPath": "can-stache-bindings/colon-bindings-output-implicit.stache",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/input.md",
+        "outputPath": "can-stache-bindings/colon-bindings-input.md",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output.md",
+        "outputPath": "can-stache-bindings/colon-bindings-output.md",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output-implicit.md",
+        "outputPath": "can-stache-bindings/colon-bindings-output-implicit.md",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/input.html",
+        "outputPath": "can-stache-bindings/colon-bindings-input.html",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output.html",
+        "outputPath": "can-stache-bindings/colon-bindings-output.html",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output-implicit.html",
+        "outputPath": "can-stache-bindings/colon-bindings-output-implicit.html",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/input.component",
+        "outputPath": "can-stache-bindings/colon-bindings-input.component",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output.component",
+        "outputPath": "can-stache-bindings/colon-bindings-output.component",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/output-implicit.component",
+        "outputPath": "can-stache-bindings/colon-bindings-output-implicit.component",
+        "type": "fixture"
+      },
+      {
+        "input": "can-stache-bindings/colon-bindings-test.js",
+        "outputPath": "can-stache-bindings/colon-bindings-test.js",
+        "type": "test"
+      }
+    ]
   },
   {
     "copy": [

--- a/lib/transforms/can-stache-bindings/colon-bindings-test.js
+++ b/lib/transforms/can-stache-bindings/colon-bindings-test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+require('mocha');
+var utils = require('../../../test/utils');
+var transforms = require('../../../');
+
+var toTest = transforms.filter(function (transform) {
+  return transform.name === 'can-stache-bindings/colon-bindings.js';
+})[0];
+
+describe('can-stache-bindings', function () {
+  it('converts bindings in `stache()` calls in .js files', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.js');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output.js');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in `stache()` calls in .js files using implicit bindings', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.js');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output-implicit.js');
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .stache files', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.stache');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output.stache');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .stache files using implicit bindings', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.stache');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output-implicit.stache');
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .md files', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.md');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output.md');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .md files using implicit bindings', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.md');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output-implicit.md');
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .html files', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.html');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output.html');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .html files using implicit bindings', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.html');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output-implicit.html');
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .component files', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.component');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output.component');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .component files using implicit bindings', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/' + toTest.fileName.replace('.js', '-input.component');
+    var outputPath = 'fixtures/' + toTest.fileName.replace('.js', '-output-implicit.component');
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+});

--- a/lib/transforms/can-stache-bindings/colon-bindings.js
+++ b/lib/transforms/can-stache-bindings/colon-bindings.js
@@ -1,0 +1,134 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = transformer;
+var kebabToCamel = function kebabToCamel(kebab) {
+  return kebab.replace(/-(.)/g, function (x, $1) {
+    return $1.toUpperCase();
+  });
+};
+
+var transformStacheExplicit = function transformStacheExplicit(src) {
+  src = src.replace(/\{\^\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\^([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':to=';
+  });
+
+  src = src.replace(/\{\(\$([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\(([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':bind=';
+  });
+
+  src = src.replace(/\{\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\{([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':from=';
+  });
+
+  src = src.replace(/\(\$([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:el:' + kebabToCamel($1) + '=';
+  });
+  src = src.replace(/\(([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:vm:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStacheContextIntuitive = function transformStacheContextIntuitive(src) {
+  src = src.replace(/\{\^\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\(\$?([^)\n]+)\)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\(\$?([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStache = function transformStache(src, useImplicitBindings) {
+  return useImplicitBindings ? transformStacheContextIntuitive(src) : transformStacheExplicit(src);
+};
+
+var transformJs = function transformJs(src, useImplicitBindings) {
+  //find call to stache with a template passed in
+  //note: only catches the call if a string is passed in and maynot work well if it's not one full string
+  return src.replace(/(\bstache\(\s*([''`]))((?:[^\\\2]|\\[\s\S])*?)(\2\s*\))/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformHtml = function transformHtml(src, useImplicitBindings) {
+  //find script tag with type text/stache
+  return src.replace(/(<script[^>]*type=("|')text\/stache\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  })
+  // find steal.js script tag
+  .replace(/(<script[^>]*src=("|').*steal\/steal\.js\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformMd = function transformMd(src, useImplicitBindings) {
+  //find ```html code blocks and treat it as stache
+  //find ```js code blocks and treat them as js
+  return src.replace(/(```)(js|html)?((?:[\s\S])+?)\1/g, function (fullStr, ticks, codeBlockType, codeBlock) {
+    codeBlockType = codeBlockType || '';
+    var output = ticks + codeBlockType;
+
+    if (codeBlockType === 'html') {
+      output += transformStache(codeBlock, useImplicitBindings);
+    } else if (codeBlockType === 'js') {
+      output += transformJs(codeBlock, useImplicitBindings);
+    } else {
+      output += codeBlock;
+    }
+    return output + ticks;
+  });
+};
+
+var transformComponent = function transformComponent(src, useImplicitBindings) {
+  //find <template> or <view> tags and treat them as stache
+  return src.replace(/(<template>|<view>)([\s\S]+?)(<\/template>|<\/view>)/g, function (fullStr, $1, $2, $3) {
+    return $1 + transformStache($2, useImplicitBindings) + $3;
+  })
+  //find <view-model> or <script type="view-model"> tags and treat them as js
+  .replace(/(<view-model>|<script[^>]*type=("|')view-model\2[^>]*>)([\s\S]+?)(<\/view-model>|<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+function transformer(file, api, options) {
+  var src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+  var useImplicitBindings = options.implicit;
+
+  if (type === 'js') {
+    src = transformJs(src, useImplicitBindings);
+  } else if (type === 'md') {
+    src = transformMd(src, useImplicitBindings);
+  } else if (type === 'html') {
+    src = transformHtml(src, useImplicitBindings);
+  } else if (type === 'stache') {
+    src = transformStache(src, useImplicitBindings);
+  } else if (type === 'component') {
+    src = transformComponent(src, useImplicitBindings);
+  }
+
+  return src;
+}
+module.exports = exports['default'];

--- a/src/templates/can-stache-bindings/colon-bindings-test.js
+++ b/src/templates/can-stache-bindings/colon-bindings-test.js
@@ -1,0 +1,79 @@
+require('mocha');
+const utils = require('../../../test/utils');
+const transforms = require('../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-stache-bindings/colon-bindings.js';
+})[0];
+
+describe('can-stache-bindings', function() {
+  it('converts bindings in `stache()` calls in .js files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in `stache()` calls in .js files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .stache files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .stache files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .md files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.md')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.md')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .md files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.md')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.md')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .html files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .html files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .component files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.component')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.component')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .component files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.component')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.component')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+});

--- a/src/templates/can-stache-bindings/colon-bindings.js
+++ b/src/templates/can-stache-bindings/colon-bindings.js
@@ -1,0 +1,129 @@
+var kebabToCamel = function (kebab) {
+  return kebab.replace(/-(.)/g, function (x, $1) {
+    return $1.toUpperCase();
+  });
+};
+
+var transformStacheExplicit = function (src) {
+  src = src.replace(/\{\^\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\^([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':to=';
+  });
+
+  src = src.replace(/\{\(\$([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\(([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':bind=';
+  });
+
+  src = src.replace(/\{\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\{([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':from=';
+  });
+
+  src = src.replace(/\(\$([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:el:' + kebabToCamel($1) + '=';
+  });
+  src = src.replace(/\(([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:vm:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStacheContextIntuitive = function (src) {
+  src = src.replace(/\{\^\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\(\$?([^)\n]+)\)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\(\$?([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStache = function (src, useImplicitBindings) {
+  return useImplicitBindings ?
+    transformStacheContextIntuitive(src) :
+    transformStacheExplicit(src);
+};
+
+var transformJs = function (src, useImplicitBindings) {
+  //find call to stache with a template passed in
+  //note: only catches the call if a string is passed in and maynot work well if it's not one full string
+  return src.replace(/(\bstache\(\s*([''`]))((?:[^\\\2]|\\[\s\S])*?)(\2\s*\))/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformHtml = function (src, useImplicitBindings) {
+  //find script tag with type text/stache
+  return src.replace(/(<script[^>]*type=("|')text\/stache\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  })
+  // find steal.js script tag
+  .replace(/(<script[^>]*src=("|').*steal\/steal\.js\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformMd = function (src, useImplicitBindings) {
+  //find ```html code blocks and treat it as stache
+  //find ```js code blocks and treat them as js
+  return src.replace(/(```)(js|html)?((?:[\s\S])+?)\1/g, function (fullStr, ticks, codeBlockType, codeBlock) {
+    codeBlockType = codeBlockType || '';
+    var output = ticks + codeBlockType;
+
+    if (codeBlockType === 'html') {
+      output += transformStache(codeBlock, useImplicitBindings);
+    } else if (codeBlockType === 'js') {
+      output += transformJs(codeBlock, useImplicitBindings);
+    } else {
+      output += codeBlock;
+    }
+    return output + ticks;
+  });
+};
+
+var transformComponent = function (src, useImplicitBindings) {
+  //find <template> or <view> tags and treat them as stache
+  return src.replace(/(<template>|<view>)([\s\S]+?)(<\/template>|<\/view>)/g, function (fullStr, $1, $2, $3) {
+    return $1 + transformStache($2, useImplicitBindings) + $3;
+  })
+  //find <view-model> or <script type="view-model"> tags and treat them as js
+  .replace(/(<view-model>|<script[^>]*type=("|')view-model\2[^>]*>)([\s\S]+?)(<\/view-model>|<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+export default function transformer(file, api, options) {
+  var src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+  var useImplicitBindings = options.implicit;
+
+  if (type === 'js') {
+    src = transformJs(src, useImplicitBindings);
+  } else if (type === 'md') {
+    src = transformMd(src, useImplicitBindings);
+  } else if (type === 'html') {
+    src = transformHtml(src, useImplicitBindings);
+  } else if (type === 'stache') {
+    src = transformStache(src, useImplicitBindings);
+  } else if (type === 'component') {
+    src = transformComponent(src, useImplicitBindings);
+  }
+
+  return src;
+}

--- a/src/templates/can-stache-bindings/input.component
+++ b/src/templates/can-stache-bindings/input.component
@@ -1,0 +1,29 @@
+<view>
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</view>
+
+<template>
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/input.html
+++ b/src/templates/can-stache-bindings/input.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/input.js
+++ b/src/templates/can-stache-bindings/input.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+  )
+});

--- a/src/templates/can-stache-bindings/input.md
+++ b/src/templates/can-stache-bindings/input.md
@@ -1,0 +1,14 @@
+```html
+<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+  )
+});
+```

--- a/src/templates/can-stache-bindings/input.stache
+++ b/src/templates/can-stache-bindings/input.stache
@@ -1,0 +1,2 @@
+<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">

--- a/src/templates/can-stache-bindings/output-implicit.component
+++ b/src/templates/can-stache-bindings/output-implicit.component
@@ -1,0 +1,29 @@
+<view>
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</view>
+
+<template>
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/output-implicit.html
+++ b/src/templates/can-stache-bindings/output-implicit.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/output-implicit.js
+++ b/src/templates/can-stache-bindings/output-implicit.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+  )
+});

--- a/src/templates/can-stache-bindings/output-implicit.md
+++ b/src/templates/can-stache-bindings/output-implicit.md
@@ -1,0 +1,14 @@
+```html
+<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+  )
+});
+```

--- a/src/templates/can-stache-bindings/output-implicit.stache
+++ b/src/templates/can-stache-bindings/output-implicit.stache
@@ -1,0 +1,2 @@
+<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">

--- a/src/templates/can-stache-bindings/output.component
+++ b/src/templates/can-stache-bindings/output.component
@@ -1,0 +1,29 @@
+<view>
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</view>
+
+<template>
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/output.html
+++ b/src/templates/can-stache-bindings/output.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</script>

--- a/src/templates/can-stache-bindings/output.js
+++ b/src/templates/can-stache-bindings/output.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+  )
+});

--- a/src/templates/can-stache-bindings/output.md
+++ b/src/templates/can-stache-bindings/output.md
@@ -1,0 +1,14 @@
+```html
+<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+  )
+});
+```

--- a/src/templates/can-stache-bindings/output.stache
+++ b/src/templates/can-stache-bindings/output.stache
@@ -1,0 +1,2 @@
+<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">

--- a/src/transforms/can-stache-bindings/colon-bindings-test.js
+++ b/src/transforms/can-stache-bindings/colon-bindings-test.js
@@ -1,0 +1,79 @@
+require('mocha');
+const utils = require('../../../test/utils');
+const transforms = require('../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-stache-bindings/colon-bindings.js';
+})[0];
+
+describe('can-stache-bindings', function() {
+  it('converts bindings in `stache()` calls in .js files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in `stache()` calls in .js files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .stache files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .stache files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .md files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.md')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.md')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .md files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.md')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.md')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .html files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .html files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+
+  it('converts bindings in .component files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.component')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output.component')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('converts bindings in .component files using implicit bindings', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/${toTest.fileName.replace('.js', '-input.component')}`;
+    const outputPath = `fixtures/${toTest.fileName.replace('.js', '-output-implicit.component')}`;
+    utils.diffFiles(fn, inputPath, outputPath, { implicit: true });
+  });
+});

--- a/src/transforms/can-stache-bindings/colon-bindings.js
+++ b/src/transforms/can-stache-bindings/colon-bindings.js
@@ -1,0 +1,129 @@
+var kebabToCamel = function (kebab) {
+  return kebab.replace(/-(.)/g, function (x, $1) {
+    return $1.toUpperCase();
+  });
+};
+
+var transformStacheExplicit = function (src) {
+  src = src.replace(/\{\^\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\^([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':to=';
+  });
+
+  src = src.replace(/\{\(\$([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\(([^)\n]+)\)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':bind=';
+  });
+
+  src = src.replace(/\{\$([^}\n]+)\}=/g, function (x, $1) {
+    return 'el:' + kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\{([^}\n]+)\}=/g, function (x, $1) {
+    return 'vm:' + kebabToCamel($1) + ':from=';
+  });
+
+  src = src.replace(/\(\$([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:el:' + kebabToCamel($1) + '=';
+  });
+  src = src.replace(/\(([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:vm:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStacheContextIntuitive = function (src) {
+  src = src.replace(/\{\^\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':to=';
+  });
+  src = src.replace(/\{\(\$?([^)\n]+)\)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':bind=';
+  });
+  src = src.replace(/\{\$?([^}\n]+)\}=/g, function (x, $1) {
+    return kebabToCamel($1) + ':from=';
+  });
+  src = src.replace(/\(\$?([^)\n]+)\)=/g, function (x, $1) {
+    return 'on:' + kebabToCamel($1) + '=';
+  });
+
+  return src;
+};
+
+var transformStache = function (src, useImplicitBindings) {
+  return useImplicitBindings ?
+    transformStacheContextIntuitive(src) :
+    transformStacheExplicit(src);
+};
+
+var transformJs = function (src, useImplicitBindings) {
+  //find call to stache with a template passed in
+  //note: only catches the call if a string is passed in and maynot work well if it's not one full string
+  return src.replace(/(\bstache\(\s*([''`]))((?:[^\\\2]|\\[\s\S])*?)(\2\s*\))/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformHtml = function (src, useImplicitBindings) {
+  //find script tag with type text/stache
+  return src.replace(/(<script[^>]*type=("|')text\/stache\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformStache($3, useImplicitBindings) + $4;
+  })
+  // find steal.js script tag
+  .replace(/(<script[^>]*src=("|').*steal\/steal\.js\2[^>]*>)([\s\S]+?)(<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+var transformMd = function (src, useImplicitBindings) {
+  //find ```html code blocks and treat it as stache
+  //find ```js code blocks and treat them as js
+  return src.replace(/(```)(js|html)?((?:[\s\S])+?)\1/g, function (fullStr, ticks, codeBlockType, codeBlock) {
+    codeBlockType = codeBlockType || '';
+    var output = ticks + codeBlockType;
+
+    if (codeBlockType === 'html') {
+      output += transformStache(codeBlock, useImplicitBindings);
+    } else if (codeBlockType === 'js') {
+      output += transformJs(codeBlock, useImplicitBindings);
+    } else {
+      output += codeBlock;
+    }
+    return output + ticks;
+  });
+};
+
+var transformComponent = function (src, useImplicitBindings) {
+  //find <template> or <view> tags and treat them as stache
+  return src.replace(/(<template>|<view>)([\s\S]+?)(<\/template>|<\/view>)/g, function (fullStr, $1, $2, $3) {
+    return $1 + transformStache($2, useImplicitBindings) + $3;
+  })
+  //find <view-model> or <script type="view-model"> tags and treat them as js
+  .replace(/(<view-model>|<script[^>]*type=("|')view-model\2[^>]*>)([\s\S]+?)(<\/view-model>|<\/script>)/g, function (fullStr, $1, quoteType, $3, $4) {
+    return $1 + transformJs($3, useImplicitBindings) + $4;
+  });
+};
+
+export default function transformer(file, api, options) {
+  var src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+  var useImplicitBindings = options.implicit;
+
+  if (type === 'js') {
+    src = transformJs(src, useImplicitBindings);
+  } else if (type === 'md') {
+    src = transformMd(src, useImplicitBindings);
+  } else if (type === 'html') {
+    src = transformHtml(src, useImplicitBindings);
+  } else if (type === 'stache') {
+    src = transformStache(src, useImplicitBindings);
+  } else if (type === 'component') {
+    src = transformComponent(src, useImplicitBindings);
+  }
+
+  return src;
+}

--- a/test/fixtures/can-stache-bindings/colon-bindings-input.component
+++ b/test/fixtures/can-stache-bindings/colon-bindings-input.component
@@ -1,0 +1,29 @@
+<view>
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</view>
+
+<template>
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-input.html
+++ b/test/fixtures/can-stache-bindings/colon-bindings-input.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-input.js
+++ b/test/fixtures/can-stache-bindings/colon-bindings-input.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+  )
+});

--- a/test/fixtures/can-stache-bindings/colon-bindings-input.md
+++ b/test/fixtures/can-stache-bindings/colon-bindings-input.md
@@ -1,0 +1,14 @@
+```html
+<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+  )
+});
+```

--- a/test/fixtures/can-stache-bindings/colon-bindings-input.stache
+++ b/test/fixtures/can-stache-bindings/colon-bindings-input.stache
@@ -1,0 +1,2 @@
+<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">

--- a/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.component
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.component
@@ -1,0 +1,29 @@
+<view>
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</view>
+
+<template>
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.html
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.js
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+  )
+});

--- a/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.md
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.md
@@ -1,0 +1,14 @@
+```html
+<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+  )
+});
+```

--- a/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.stache
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output-implicit.stache
@@ -1,0 +1,2 @@
+<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">

--- a/test/fixtures/can-stache-bindings/colon-bindings-output.component
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output.component
@@ -1,0 +1,29 @@
+<view>
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</view>
+
+<template>
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</template>
+
+<view-model>
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</view-model>
+
+<script type="view-model">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-output.html
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output.html
@@ -1,0 +1,14 @@
+<script type="text/stache">
+  <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+</script>
+
+<script src="../foo/bar/steal/steal.js">
+  Component.extend({
+    tag: 'my-tag',
+    template: stache(
+      '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    )
+  });
+</script>

--- a/test/fixtures/can-stache-bindings/colon-bindings-output.js
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output.js
@@ -1,0 +1,7 @@
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+  )
+});

--- a/test/fixtures/can-stache-bindings/colon-bindings-output.md
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output.md
@@ -1,0 +1,14 @@
+```html
+<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+```
+
+```js
+Component.extend({
+  tag: 'my-tag',
+  template: stache(
+    '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+  )
+});
+```

--- a/test/fixtures/can-stache-bindings/colon-bindings-output.stache
+++ b/test/fixtures/can-stache-bindings/colon-bindings-output.stache
@@ -1,0 +1,2 @@
+<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 require('../lib/transforms/can-component-rename/can-component-rename-test.js');
+require('../lib/transforms/can-stache-bindings/colon-bindings-test.js');
 require('../lib/transforms/can-extend/can-extend-test.js');
 require('../lib/transforms/can-data/can-data-test.js');
 require('../lib/transforms/can-component/import-test.js');


### PR DESCRIPTION
To convert to the explicit bindings:

```
can-migrate --apply src/**/*.html --transform can-stache-bindings/colon-bindings.js
```

To use implicit bindings:

```
can-migrate --apply src/**/*.html --transform can-stache-bindings/colon-bindings.js --implicit
```

This codemod works on `.stache`, `.js`, `.html`, `.md`, and `.component` files.