### PR TITLE
Added transform for changing value to default only in DefineMap extends

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -425,6 +425,30 @@
         "outputPath": "can-stache/console-log-output.stache",
         "type": "fixture",
         "version": "4"
+      },
+      {
+        "input": "can-define/default.js",
+        "outputPath": "can-define/default.js",
+        "type": "transform",
+        "version": "4"
+      },
+      {
+        "input": "can-define/default-test.js",
+        "outputPath": "can-define/default-test.js",
+        "type": "test",
+        "version": "4"
+      },
+      {
+        "input": "can-define/default-input.js",
+        "outputPath": "can-define/default-input.js",
+        "type": "fixture",
+        "version": "4"
+      },
+      {
+        "input": "can-define/default-output.js",
+        "outputPath": "can-define/default-output.js",
+        "type": "fixture",
+        "version": "4"
       }
     ]
   },

--- a/lib/transforms/version-4/can-define/default-test.js
+++ b/lib/transforms/version-4/can-define/default-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('mocha');
+var utils = require('../../../../test/utils');
+var transforms = require('../../../../');
+
+var toTest = transforms.filter(function (transform) {
+  return transform.name === 'can-define/default.js';
+})[0];
+
+describe('can-define default transform', function () {
+  it('converts `value` to `default` only in DefineMap extends', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-input.js');
+    var outputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-output.js');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/lib/transforms/version-4/can-define/default.js
+++ b/lib/transforms/version-4/can-define/default.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = transformer;
+function transformer(file, api) {
+  var j = api.jscodeshift;
+  var root = j(file.source);
+
+  return root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(function (expressionStatement) {
+    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(function (identifier) {
+      identifier.node.name = 'default';
+    });
+  }).toSource();
+}
+module.exports = exports['default'];

--- a/lib/transforms/version-4/update/can-4.js
+++ b/lib/transforms/version-4/update/can-4.js
@@ -49,7 +49,7 @@ function transformer(file, api, options) {
   src = (0, _routeHelpers2.default)(src);
   src = (0, _consoleLog2.default)(src);
   src = (0, _batch2.default)(file, api, options);
-  src = (0, _default2.default)(src);
+  src = (0, _default2.default)(file, api);
 
   return src;
 }

--- a/lib/transforms/version-4/update/can-4.js
+++ b/lib/transforms/version-4/update/can-4.js
@@ -33,6 +33,10 @@ var _batch = require('../can-queues/batch');
 
 var _batch2 = _interopRequireDefault(_batch);
 
+var _default = require('../can-define/default');
+
+var _default2 = _interopRequireDefault(_default);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function transformer(file, api, options) {
@@ -45,6 +49,7 @@ function transformer(file, api, options) {
   src = (0, _routeHelpers2.default)(src);
   src = (0, _consoleLog2.default)(src);
   src = (0, _batch2.default)(file, api, options);
+  src = (0, _default2.default)(src);
 
   return src;
 }

--- a/lib/utils/renameImport.js
+++ b/lib/utils/renameImport.js
@@ -24,7 +24,7 @@ function replaceImport(ast, options) {
    * Utility for replacing an import statement of the form:
    *   `import <oldLocalName> from <oldSourceValue>
    * Then it replaces references of <oldLocalName> with the new local name.
-   * 
+   *
    * Options:
    *   oldSourceValues {Array<String>} possible values for <oldSourceValue>
    *   newSourceValue {String} new source value to use (will replace <oldSourceValue>)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "mocha test/ --compilers js:babel-core/register",
-    "test": "npm run generate && npm run compile && npm run jshint && npm run mocha"
+    "test": "npm run generate && npm run compile && npm run jshint && npm run mocha",
+    "test-no-jshint": "npm run generate && npm run compile && npm run mocha"
   },
   "repository": {
     "type": "git",

--- a/src/templates/can-define/default-input.js
+++ b/src/templates/can-define/default-input.js
@@ -1,0 +1,18 @@
+
+let ViewModel = DefineMap.extend({
+  myProp: {
+    value: 'something'
+  }
+});
+
+let obj = {
+  myProp: {
+    value: 'something else'
+  }
+}
+
+let AnotherVM = Something.extend({
+  myProp: {
+    value: 'something'
+  }
+});

--- a/src/templates/can-define/default-output.js
+++ b/src/templates/can-define/default-output.js
@@ -1,0 +1,18 @@
+
+let ViewModel = DefineMap.extend({
+  myProp: {
+    default: 'something'
+  }
+});
+
+let obj = {
+  myProp: {
+    value: 'something else'
+  }
+}
+
+let AnotherVM = Something.extend({
+  myProp: {
+    value: 'something'
+  }
+});

--- a/src/templates/can-define/default-test.js
+++ b/src/templates/can-define/default-test.js
@@ -1,0 +1,17 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define/default.js';
+})[0];
+
+describe('can-define default transform', function() {
+  it('converts `value` to `default` only in DefineMap extends', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/templates/can-define/default.js
+++ b/src/templates/can-define/default.js
@@ -1,0 +1,16 @@
+export default function transformer(file, api) {
+  let j = api.jscodeshift;
+  let root = j(file.source);
+
+  return root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(identifier => {
+      identifier.node.name = 'default';
+    });
+  }).toSource();
+}

--- a/src/templates/update/can-4.js
+++ b/src/templates/update/can-4.js
@@ -18,7 +18,7 @@ export default function transformer(file, api, options) {
   src = routeHelpers(src);
   src = consoleLog(src);
   src = batch(file, api, options);
-  src = valueToDefault(src);
+  src = valueToDefault(file, api);
 
   return src;
 }

--- a/src/templates/update/can-4.js
+++ b/src/templates/update/can-4.js
@@ -6,6 +6,7 @@ import start from '../can-route/start';
 import routeHelpers from '../can-stache/route-helpers';
 import consoleLog from '../can-stache/console-log';
 import batch from '../can-queues/batch';
+import valueToDefault from '../can-define/default';
 
 export default function transformer(file, api, options) {
   let src = file.source;
@@ -17,6 +18,7 @@ export default function transformer(file, api, options) {
   src = routeHelpers(src);
   src = consoleLog(src);
   src = batch(file, api, options);
+  src = valueToDefault(src);
 
   return src;
 }

--- a/src/transforms/version-4/can-define/default-test.js
+++ b/src/transforms/version-4/can-define/default-test.js
@@ -1,0 +1,17 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define/default.js';
+})[0];
+
+describe('can-define default transform', function() {
+  it('converts `value` to `default` only in DefineMap extends', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/transforms/version-4/can-define/default.js
+++ b/src/transforms/version-4/can-define/default.js
@@ -1,0 +1,16 @@
+export default function transformer(file, api) {
+  let j = api.jscodeshift;
+  let root = j(file.source);
+
+  return root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(identifier => {
+      identifier.node.name = 'default';
+    });
+  }).toSource();
+}

--- a/src/transforms/version-4/update/can-4.js
+++ b/src/transforms/version-4/update/can-4.js
@@ -18,7 +18,7 @@ export default function transformer(file, api, options) {
   src = routeHelpers(src);
   src = consoleLog(src);
   src = batch(file, api, options);
-  src = valueToDefault(src);
+  src = valueToDefault(file, api);
 
   return src;
 }

--- a/src/transforms/version-4/update/can-4.js
+++ b/src/transforms/version-4/update/can-4.js
@@ -6,6 +6,7 @@ import start from '../can-route/start';
 import routeHelpers from '../can-stache/route-helpers';
 import consoleLog from '../can-stache/console-log';
 import batch from '../can-queues/batch';
+import valueToDefault from '../can-define/default';
 
 export default function transformer(file, api, options) {
   let src = file.source;
@@ -17,6 +18,7 @@ export default function transformer(file, api, options) {
   src = routeHelpers(src);
   src = consoleLog(src);
   src = batch(file, api, options);
+  src = valueToDefault(src);
 
   return src;
 }

--- a/src/utils/renameImport.js
+++ b/src/utils/renameImport.js
@@ -2,7 +2,7 @@
  * Utility for replacing an import statement of the form:
  *   `import <oldLocalName> from <oldSourceValue>
  * Then it replaces references of <oldLocalName> with the new local name.
- * 
+ *
  * Options:
  *   oldSourceValues {Array<String>} possible values for <oldSourceValue>
  *   newSourceValue {String} new source value to use (will replace <oldSourceValue>)

--- a/test/fixtures/version-4/can-define/default-input.js
+++ b/test/fixtures/version-4/can-define/default-input.js
@@ -1,0 +1,18 @@
+
+let ViewModel = DefineMap.extend({
+  myProp: {
+    value: 'something'
+  }
+});
+
+let obj = {
+  myProp: {
+    value: 'something else'
+  }
+}
+
+let AnotherVM = Something.extend({
+  myProp: {
+    value: 'something'
+  }
+});

--- a/test/fixtures/version-4/can-define/default-output.js
+++ b/test/fixtures/version-4/can-define/default-output.js
@@ -1,0 +1,18 @@
+
+let ViewModel = DefineMap.extend({
+  myProp: {
+    default: 'something'
+  }
+});
+
+let obj = {
+  myProp: {
+    value: 'something else'
+  }
+}
+
+let AnotherVM = Something.extend({
+  myProp: {
+    value: 'something'
+  }
+});

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ require('../lib/transforms/version-4/can-route/register-test.js');
 require('../lib/transforms/version-4/can-queues/batch-test.js');
 require('../lib/transforms/version-4/can-stache/route-helpers-test.js');
 require('../lib/transforms/version-4/can-stache/console-log-test.js');
+require('../lib/transforms/version-4/can-define/default-test.js');
 require('../lib/transforms/version-3/can-component/import-test.js');
 require('../lib/transforms/version-3/can-construct/import-test.js');
 require('../lib/transforms/version-3/can-construct-super/import-test.js');

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,29 +4,29 @@ const assert = require('assert');
 const disparity = require('disparity');
 const jscodeshift = require('jscodeshift');
 
-export default {
-  diffFiles(fn, inputPath, outputPath, options = {}) {
-    const result = fn({
-      path: path.join(__dirname, inputPath),
-      source: fs.readFileSync(path.join(__dirname, inputPath), 'utf8')
-    }, {
-        jscodeshift: jscodeshift,
-        stats: function () { }
-      }, Object.assign({}, {
-        printOptions: {
-          quote: 'single'
-        }
-      }, options));
+function diffFiles(fn, inputPath, outputPath, options = {}) {
+  const result = fn({
+    path: path.join(__dirname, inputPath),
+    source: fs.readFileSync(path.join(__dirname, inputPath), 'utf8')
+  }, {
+      jscodeshift: jscodeshift,
+      stats: function () { }
+    }, Object.assign({}, {
+      printOptions: {
+        quote: 'single'
+      }
+    }, options));
 
-    // console.log('\n\n', result, '\n\n');
+  // console.log('\n\n', result, '\n\n');
 
-    const diff = disparity.unified(fs.readFileSync(path.join(__dirname, outputPath), 'utf8').trim(), result.trim(), {
-      paths: [
-        `${inputPath} (transformed)`,
-        outputPath
-      ]
-    });
+  const diff = disparity.unified(fs.readFileSync(path.join(__dirname, outputPath), 'utf8').trim(), result.trim(), {
+    paths: [
+      `${inputPath} (transformed)`,
+      outputPath
+    ]
+  });
 
-    assert.equal(diff, '', `\n${diff}`);
-  }
-};
+  assert.equal(diff, '', `\n${diff}`);
+}
+
+module.exports.diffFiles = diffFiles;


### PR DESCRIPTION
This uses the jscodeshift api to ensure that properties with name "value" get changed to "default" only when in a `DefineMap.extend({})` call expression.