### PR TITLE
Filter paths and remove node_modules if present

### DIFF
--- a/bin/can-migrate.js
+++ b/bin/can-migrate.js
@@ -78,6 +78,10 @@ if(!checkGitStatus(cli.flags.force)) {
 }
 
 globby(cli.input).then((paths) => {
+  paths = paths.filter((path) => {
+    return path.indexOf('node_modules') === -1;
+  });
+
   let toApply = transforms;
   let config;
 


### PR DESCRIPTION
This is so that if someone gives the glob `**/*.*` it will not try to transform anything in `node_modules`.