### PR TITLE
Added wrapper for JS codeshift that manually runs transforms on non-j…

### DIFF
--- a/bin/can-migrate.js
+++ b/bin/can-migrate.js
@@ -8,6 +8,7 @@ const globby = require('globby');
 const series = require('promise-map-series');
 const isGitClean = require('is-git-clean');
 const transforms = require('../');
+const runTransform = require('../lib/utils/runTransform');
 
 const ENSURE_BACKUP_MESSAGE = 'Ensure you have a backup of your tests or commit the latest changes before continuing.';
 
@@ -102,7 +103,6 @@ globby(cli.input).then((paths) => {
   }
 
   return series(toApply, (transform) => {
-    const jscodeshiftPath = require.resolve('.bin/jscodeshift');
     let args = [
       '-t', transform.file
     ];
@@ -131,9 +131,7 @@ globby(cli.input).then((paths) => {
       }
     }
 
-    args = args.concat(paths);
+    runTransform(transform, paths, args, cli.flags.apply);
 
-    return execa(jscodeshiftPath, args, { stdio: 'inherit' }).then(() => {
-    }).catch(console.error.bind(console));
   });
 });

--- a/lib/utils/runTransform.js
+++ b/lib/utils/runTransform.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var path = require('path');
+var execa = require('execa');
+var fs = require('fs');
+
+var noop = function noop() {
+  return this;
+};
+var mockRoot = function mockRoot(source) {
+  this.source = source;
+};
+mockRoot.prototype.find = noop;
+mockRoot.prototype.toSource = function () {
+  return this.source;
+};
+mockRoot.prototype.forEach = noop;
+mockRoot.prototype.filter = noop;
+var mockJscodeshift = function mockJscodeshift(source) {
+  return new mockRoot(source);
+};
+mockJscodeshift.CallExperssion = noop;
+mockJscodeshift.Identifier = noop;
+
+var mockApi = {
+  jscodeshift: mockJscodeshift
+};
+
+function runTransform(transform, paths, args, apply) {
+  var jscodeshiftPath = require.resolve('.bin/jscodeshift');
+  var transformFunc = require(transform.file);
+
+  var jsPaths = [];
+  var otherPaths = [];
+
+  for (var i = 0; i < paths.length; i++) {
+    if (path.extname(paths[i]) === '.js') {
+      jsPaths.push(paths[i]);
+    } else {
+      otherPaths.push(paths[i]);
+    }
+  }
+
+  // Run the transform on non-js files
+  for (var _i = 0; _i < otherPaths.length; _i++) {
+    var file = {
+      path: otherPaths[_i],
+      source: fs.readFileSync(otherPaths[_i], 'utf8')
+    };
+    var options = {};
+    var newSource = transformFunc(file, mockApi, options);
+    // Write changes to file if apply specified
+    if (apply) {
+      fs.writeFileSync(file.path, newSource);
+    }
+  }
+
+  args = args.concat(jsPaths);
+
+  return execa(jscodeshiftPath, args, { stdio: 'inherit' }).then(function () {}).catch(console.error.bind(console));
+}
+
+module.exports = runTransform;

--- a/lib/utils/runTransform.js
+++ b/lib/utils/runTransform.js
@@ -21,6 +21,9 @@ var mockJscodeshift = function mockJscodeshift(source) {
 };
 mockJscodeshift.CallExperssion = noop;
 mockJscodeshift.Identifier = noop;
+mockJscodeshift.identifier = noop;
+mockJscodeshift.literal = noop;
+mockJscodeshift.property = noop;
 
 var mockApi = {
   jscodeshift: mockJscodeshift

--- a/src/utils/runTransform.js
+++ b/src/utils/runTransform.js
@@ -1,0 +1,54 @@
+
+const path = require('path');
+const execa = require('execa');
+const fs = require('fs');
+
+let noop = function() { return this; };
+let mockRoot = function(source) { this.source = source; };
+mockRoot.prototype.find = noop;
+mockRoot.prototype.toSource = function() { return this.source; };
+mockRoot.prototype.forEach = noop;
+mockRoot.prototype.filter = noop;
+let mockJscodeshift = function(source) { return new mockRoot(source); };
+mockJscodeshift.CallExperssion = noop;
+mockJscodeshift.Identifier = noop;
+
+const mockApi = {
+  jscodeshift: mockJscodeshift
+};
+
+function runTransform(transform, paths, args, apply) {
+  const jscodeshiftPath = require.resolve('.bin/jscodeshift');
+  const transformFunc = require(transform.file);
+
+  let jsPaths = [];
+  let otherPaths = [];
+
+  for (let i = 0; i < paths.length; i++) {
+    if(path.extname(paths[i]) === '.js') {
+      jsPaths.push(paths[i]);
+    }
+    else {
+      otherPaths.push(paths[i]);
+    }
+  }
+
+  // Run the transform on non-js files
+  for (let i = 0; i < otherPaths.length; i++) {
+    let file = {
+      path: otherPaths[i],
+      source: fs.readFileSync(otherPaths[i], 'utf8')
+    };
+    let options = {};
+    let newSource = transformFunc(file, mockApi, options);
+    // Write changes to file if apply specified
+    if (apply) { fs.writeFileSync(file.path, newSource); }
+  }
+
+  args = args.concat(jsPaths);
+
+  return execa(jscodeshiftPath, args, { stdio: 'inherit' }).then(() => {
+  }).catch(console.error.bind(console));
+}
+
+module.exports = runTransform;

--- a/src/utils/runTransform.js
+++ b/src/utils/runTransform.js
@@ -12,6 +12,9 @@ mockRoot.prototype.filter = noop;
 let mockJscodeshift = function(source) { return new mockRoot(source); };
 mockJscodeshift.CallExperssion = noop;
 mockJscodeshift.Identifier = noop;
+mockJscodeshift.identifier = noop;
+mockJscodeshift.literal = noop;
+mockJscodeshift.property = noop;
 
 const mockApi = {
   jscodeshift: mockJscodeshift


### PR DESCRIPTION
…s files

This makes a mock jscodeshift API and for non-javascript files and only really runs jscodeshift on proper js files.