### PR TITLE
Added test and transform for changing set to update in DefineMaps and…

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -223,6 +223,30 @@
         "outputPath": "can-data/can-data-test.js",
         "type": "test",
         "version": "3"
+      },
+      {
+        "input": "can-define/set-to-update.js",
+        "outputPath": "can-define/set-to-update.js",
+        "type": "transform",
+        "version": "3"
+      },
+      {
+        "input": "can-define/set-to-update-test.js",
+        "outputPath": "can-define/set-to-update-test.js",
+        "type": "test",
+        "version": "3"
+      },
+      {
+        "input": "can-define/set-to-update-input.js",
+        "outputPath": "can-define/set-to-update-input.js",
+        "type": "fixture",
+        "version": "3"
+      },
+      {
+        "input": "can-define/set-to-update-output.js",
+        "outputPath": "can-define/set-to-update-output.js",
+        "type": "fixture",
+        "version": "3"
       }
     ]
   },

--- a/lib/transforms/version-3/can-define/set-to-update-test.js
+++ b/lib/transforms/version-3/can-define/set-to-update-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('mocha');
+var utils = require('../../../../test/utils');
+var transforms = require('../../../../');
+
+var toTest = transforms.filter(function (transform) {
+  return transform.name === 'can-define/set-to-update.js';
+})[0];
+
+describe('can-define set to update transform', function () {
+  it('converts `set()` to `update()` only for DefineMap and DefineList instances', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/version-3/' + toTest.fileName.replace('.js', '-input.js');
+    var outputPath = 'fixtures/version-3/' + toTest.fileName.replace('.js', '-output.js');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/lib/transforms/version-3/can-define/set-to-update.js
+++ b/lib/transforms/version-3/can-define/set-to-update.js
@@ -1,0 +1,55 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = transformer;
+function transformer(file, api) {
+  var j = api.jscodeshift;
+  var root = j(file.source);
+
+  var src = root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(function (expressionStatement) {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(function (expression) {
+      if (expression.value.callee.property.name === 'set') {
+        if (expression.node.arguments.length === 2) {
+          var firstArg = expression.node.arguments[0];
+          var secondArg = expression.node.arguments[1];
+          if (firstArg.type === 'ObjectExpression' && typeof secondArg.value === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  root = j(src);
+
+  src = root.find(j.NewExpression, {
+    callee: {
+      name: 'DefineList'
+    }
+  }).forEach(function (expressionStatement) {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(function (expression) {
+      if (expression.value.callee.property.name === 'set') {
+        if (expression.node.arguments.length === 2) {
+          var firstArg = expression.node.arguments[0];
+          var secondArg = expression.node.arguments[1];
+          if (firstArg.type === 'ArrayExpression' && typeof secondArg.value === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  return src;
+}
+module.exports = exports['default'];

--- a/lib/transforms/version-4/can-define/for-each.js
+++ b/lib/transforms/version-4/can-define/for-each.js
@@ -16,7 +16,9 @@ function transformer(file, api) {
     }
   }).forEach(function (expressionStatement) {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(function (expression) {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 
@@ -28,7 +30,9 @@ function transformer(file, api) {
     }
   }).forEach(function (expressionStatement) {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(function (expression) {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 

--- a/src/templates/can-define/for-each.js
+++ b/src/templates/can-define/for-each.js
@@ -11,7 +11,9 @@ export default function transformer(file, api) {
     }
   }).forEach(expressionStatement => {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 
@@ -23,7 +25,9 @@ export default function transformer(file, api) {
     }
   }).forEach(expressionStatement => {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 

--- a/src/templates/can-define/set-to-update-input.js
+++ b/src/templates/can-define/set-to-update-input.js
@@ -1,0 +1,29 @@
+
+let ViewModel = DefineMap.extend({
+  prop1: {
+    value: 'prop1 value'
+  },
+  prop2: {
+    value: 'prop2 value'
+  },
+  setMap: {
+    value: function() {
+      this.set({}, true);
+    }
+  }
+});
+
+let MyList = new DefineList([
+  { prop1: 'prop1 value' },
+  { prop2: function() {
+      this.set([], true);
+    }
+  }
+]);
+
+let obj = {
+  someProp: 'hello',
+  setMap: function() {
+    this.set({}, true);
+  }
+}

--- a/src/templates/can-define/set-to-update-output.js
+++ b/src/templates/can-define/set-to-update-output.js
@@ -1,0 +1,29 @@
+
+let ViewModel = DefineMap.extend({
+  prop1: {
+    value: 'prop1 value'
+  },
+  prop2: {
+    value: 'prop2 value'
+  },
+  setMap: {
+    value: function() {
+      this.update({});
+    }
+  }
+});
+
+let MyList = new DefineList([
+  { prop1: 'prop1 value' },
+  { prop2: function() {
+      this.update([]);
+    }
+  }
+]);
+
+let obj = {
+  someProp: 'hello',
+  setMap: function() {
+    this.set({}, true);
+  }
+}

--- a/src/templates/can-define/set-to-update-test.js
+++ b/src/templates/can-define/set-to-update-test.js
@@ -1,0 +1,17 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define/set-to-update.js';
+})[0];
+
+describe('can-define set to update transform', function() {
+  it('converts `set()` to `update()` only for DefineMap and DefineList instances', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-3/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-3/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/templates/can-define/set-to-update.js
+++ b/src/templates/can-define/set-to-update.js
@@ -1,0 +1,49 @@
+
+export default function transformer(file, api) {
+  let j = api.jscodeshift;
+  let root = j(file.source);
+
+  let src = root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
+      if (expression.value.callee.property.name === 'set') {
+        if(expression.node.arguments.length === 2) {
+          const firstArg = expression.node.arguments[0];
+          const secondArg = expression.node.arguments[1];
+          if(firstArg.type === 'ObjectExpression' && typeof(secondArg.value) === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  root = j(src);
+
+  src = root.find(j.NewExpression, {
+    callee: {
+      name: 'DefineList'
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
+      if (expression.value.callee.property.name === 'set') {
+        if(expression.node.arguments.length === 2) {
+          const firstArg = expression.node.arguments[0];
+          const secondArg = expression.node.arguments[1];
+          if(firstArg.type === 'ArrayExpression' && typeof(secondArg.value) === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  return src;
+}

--- a/src/transforms/version-3/can-define/set-to-update-test.js
+++ b/src/transforms/version-3/can-define/set-to-update-test.js
@@ -1,0 +1,17 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-define/set-to-update.js';
+})[0];
+
+describe('can-define set to update transform', function() {
+  it('converts `set()` to `update()` only for DefineMap and DefineList instances', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-3/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-3/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/transforms/version-3/can-define/set-to-update.js
+++ b/src/transforms/version-3/can-define/set-to-update.js
@@ -1,0 +1,49 @@
+
+export default function transformer(file, api) {
+  let j = api.jscodeshift;
+  let root = j(file.source);
+
+  let src = root.find(j.CallExpression, {
+    callee: {
+      object: {
+        name: 'DefineMap'
+      }
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
+      if (expression.value.callee.property.name === 'set') {
+        if(expression.node.arguments.length === 2) {
+          const firstArg = expression.node.arguments[0];
+          const secondArg = expression.node.arguments[1];
+          if(firstArg.type === 'ObjectExpression' && typeof(secondArg.value) === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  root = j(src);
+
+  src = root.find(j.NewExpression, {
+    callee: {
+      name: 'DefineList'
+    }
+  }).forEach(expressionStatement => {
+    j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
+      if (expression.value.callee.property.name === 'set') {
+        if(expression.node.arguments.length === 2) {
+          const firstArg = expression.node.arguments[0];
+          const secondArg = expression.node.arguments[1];
+          if(firstArg.type === 'ArrayExpression' && typeof(secondArg.value) === 'boolean') {
+            expression.node.arguments.splice(-1);
+          }
+        }
+        expression.value.callee.property.name = 'update';
+      }
+    });
+  }).toSource();
+
+  return src;
+}

--- a/src/transforms/version-4/can-define/for-each.js
+++ b/src/transforms/version-4/can-define/for-each.js
@@ -11,7 +11,9 @@ export default function transformer(file, api) {
     }
   }).forEach(expressionStatement => {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 
@@ -23,7 +25,9 @@ export default function transformer(file, api) {
     }
   }).forEach(expressionStatement => {
     j(expressionStatement).find(j.CallExpression, { callee: { object: { type: 'ThisExpression' } } }).forEach(expression => {
-      expression.value.callee.property.name = 'forEach';
+      if (expression.value.callee.property.name === 'each') {
+        expression.value.callee.property.name = 'forEach';
+      }
     });
   }).toSource();
 

--- a/test/fixtures/version-3/can-define/set-to-update-input.js
+++ b/test/fixtures/version-3/can-define/set-to-update-input.js
@@ -1,0 +1,29 @@
+
+let ViewModel = DefineMap.extend({
+  prop1: {
+    value: 'prop1 value'
+  },
+  prop2: {
+    value: 'prop2 value'
+  },
+  setMap: {
+    value: function() {
+      this.set({}, true);
+    }
+  }
+});
+
+let MyList = new DefineList([
+  { prop1: 'prop1 value' },
+  { prop2: function() {
+      this.set([], true);
+    }
+  }
+]);
+
+let obj = {
+  someProp: 'hello',
+  setMap: function() {
+    this.set({}, true);
+  }
+}

--- a/test/fixtures/version-3/can-define/set-to-update-output.js
+++ b/test/fixtures/version-3/can-define/set-to-update-output.js
@@ -1,0 +1,29 @@
+
+let ViewModel = DefineMap.extend({
+  prop1: {
+    value: 'prop1 value'
+  },
+  prop2: {
+    value: 'prop2 value'
+  },
+  setMap: {
+    value: function() {
+      this.update({});
+    }
+  }
+});
+
+let MyList = new DefineList([
+  { prop1: 'prop1 value' },
+  { prop2: function() {
+      this.update([]);
+    }
+  }
+]);
+
+let obj = {
+  someProp: 'hello',
+  setMap: function() {
+    this.set({}, true);
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ require('../lib/transforms/version-3/can-component-rename/can-component-rename-t
 require('../lib/transforms/version-3/can-stache-bindings/colon-bindings-test.js');
 require('../lib/transforms/version-3/can-extend/can-extend-test.js');
 require('../lib/transforms/version-3/can-data/can-data-test.js');
+require('../lib/transforms/version-3/can-define/set-to-update-test.js');
 require('../lib/transforms/version-4/can-stache/scope-test.js');
 require('../lib/transforms/version-4/can-route/page-test.js');
 require('../lib/transforms/version-4/can-route/start-test.js');


### PR DESCRIPTION
… DefineLists

This will change `set()` in DefineMaps and DefineLists to `update()`.

As in https://github.com/canjs/can-migrate/pull/35 there is no good way to change an instance of a DefineMap or DefineList as the ast tree does not contain the type.