### PR TITLE
Prop to propfrom

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -467,6 +467,30 @@
         "outputPath": "can-define/for-each-output.js",
         "type": "fixture",
         "version": "4"
+      },
+      {
+        "input": "can-stache/attr-from.js",
+        "outputPath": "can-stache/attr-from.js",
+        "type": "transform",
+        "version": "4"
+      },
+      {
+        "input": "can-stache/attr-from-test.js",
+        "outputPath": "can-stache/attr-from-test.js",
+        "type": "test",
+        "version": "4"
+      },
+      {
+        "input": "can-stache/attr-from-input.stache",
+        "outputPath": "can-stache/attr-from-input.stache",
+        "type": "fixture",
+        "version": "4"
+      },
+      {
+        "input": "can-stache/attr-from-output.stache",
+        "outputPath": "can-stache/attr-from-output.stache",
+        "type": "fixture",
+        "version": "4"
       }
     ]
   },

--- a/lib/transforms/version-4/can-stache/attr-from-test.js
+++ b/lib/transforms/version-4/can-stache/attr-from-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('mocha');
+var utils = require('../../../../test/utils');
+var transforms = require('../../../../');
+
+var toTest = transforms.filter(function (transform) {
+  return transform.name === 'can-stache/attr-from.js';
+})[0];
+
+describe('can-stache attr to attr:from transform', function () {
+
+  it('converts `prop="value"` to `prop:from="value"` when not a global element attr', function () {
+    var fn = require(toTest.file);
+    var inputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-input.stache');
+    var outputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-output.stache');
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/lib/transforms/version-4/can-stache/attr-from.js
+++ b/lib/transforms/version-4/can-stache/attr-from.js
@@ -1,0 +1,28 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = transformer;
+
+var _canStache = require('can-stache');
+
+var _canStache2 = _interopRequireDefault(_canStache);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function transformer(file) {
+  var src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+
+  if (type === 'stache') {
+    var renderer = (0, _canStache2.default)(src);
+    debugger;
+  }
+
+  // src = src.replace('%index', 'scope.index');
+
+  return src;
+}
+module.exports = exports['default'];

--- a/lib/transforms/version-4/can-stache/attr-from.js
+++ b/lib/transforms/version-4/can-stache/attr-from.js
@@ -5,11 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = transformer;
 
-var _canStache = require('can-stache');
-
-var _canStache2 = _interopRequireDefault(_canStache);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete', 'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange', 'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick', 'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave', 'ondragover', 'ondragstart', 'ondrop', 'ondurationchange', 'onemptied', 'onended', 'onerror', 'onfocus', 'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown', 'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onmousewheel', 'onpause', 'onplay', 'onplaying', 'onprogress', 'onratechange', 'onreset', 'onresize', 'onscroll', 'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort', 'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle', 'onvolumechange', 'onwaiting', 'accesskey', 'class', 'contenteditable', 'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style', 'tabindex', 'title'];
 
 function transformer(file) {
   var src = file.source;
@@ -17,11 +13,17 @@ function transformer(file) {
   var type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
-    var renderer = (0, _canStache2.default)(src);
-    debugger;
+    var alphaNumeric = 'A-Za-z0-9';
+    var alphaNumericHU = '-:_' + alphaNumeric;
+    var attributeRegexp = new RegExp("[" + alphaNumericHU + "]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    var attributes = src.match(attributeRegexp);
+    for (var i = 0; i < attributes.length; i++) {
+      var attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+        src = src.replace(attribute, attribute + ':bind');
+      }
+    }
   }
-
-  // src = src.replace('%index', 'scope.index');
 
   return src;
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/canjs/can-migrate#readme",
   "dependencies": {
+    "can-stache": "^4.0.2",
     "deep-assign": "^2.0.0",
     "disparity": "^2.0.0",
     "execa": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "homepage": "https://github.com/canjs/can-migrate#readme",
   "dependencies": {
-    "can-stache": "^4.0.2",
     "deep-assign": "^2.0.0",
     "disparity": "^2.0.0",
     "execa": "^0.9.0",

--- a/src/templates/can-stache/attr-from-input.stache
+++ b/src/templates/can-stache/attr-from-input.stache
@@ -1,0 +1,18 @@
+<some-element xml:lang='value' xml:base='value' aria-labelledby='value' onabort='value'
+  onautocomplete='value' onautocompleteerror='value' onblur='value' oncancel='value'
+  oncanplay='value' oncanplaythrough='value' onchange='value' onclick='value' onclose='value'
+  oncontextmenu='value' oncuechange='value' ondblclick='value' ondrag='value' ondragend='value'
+  ondragenter='value' ondragexit='value' ondragleave='value' ondragover='value' ondragstart='value'
+  ondrop='value' ondurationchange='value' onemptied='value' onended='value' onerror='value'
+  onfocus='value' oninput='value' oninvalid='value' onkeydown='value' onkeypress='value'
+  onkeyup='value' onload='value' onloadeddata='value' onloadedmetadata='value' onloadstart='value'
+  onmousedown='value' onmouseenter='value' onmouseleave='value' onmousemove='value'
+  onmouseout='value' onmouseover='value' onmouseup='value' onmousewheel='value' onpause='value'
+  onplay='value' onplaying='value' onprogress='value' onratechange='value' onreset='value'
+  onresize='value' onscroll='value' onseeked='value' onseeking='value' onselect='value'
+  onshow='value' onsort='value' onstalled='value' onsubmit='value' onsuspend='value'
+  ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
+  class='value' contenteditable='value' contextmenu='value' data-something='value'
+  dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
+  tabindex='value' title='value' prop='value'>
+</some-element>

--- a/src/templates/can-stache/attr-from-output.stache
+++ b/src/templates/can-stache/attr-from-output.stache
@@ -1,0 +1,18 @@
+<some-element xml:lang='value' xml:base='value' aria-labelledby='value' onabort='value'
+  onautocomplete='value' onautocompleteerror='value' onblur='value' oncancel='value'
+  oncanplay='value' oncanplaythrough='value' onchange='value' onclick='value' onclose='value'
+  oncontextmenu='value' oncuechange='value' ondblclick='value' ondrag='value' ondragend='value'
+  ondragenter='value' ondragexit='value' ondragleave='value' ondragover='value' ondragstart='value'
+  ondrop='value' ondurationchange='value' onemptied='value' onended='value' onerror='value'
+  onfocus='value' oninput='value' oninvalid='value' onkeydown='value' onkeypress='value'
+  onkeyup='value' onload='value' onloadeddata='value' onloadedmetadata='value' onloadstart='value'
+  onmousedown='value' onmouseenter='value' onmouseleave='value' onmousemove='value'
+  onmouseout='value' onmouseover='value' onmouseup='value' onmousewheel='value' onpause='value'
+  onplay='value' onplaying='value' onprogress='value' onratechange='value' onreset='value'
+  onresize='value' onscroll='value' onseeked='value' onseeking='value' onselect='value'
+  onshow='value' onsort='value' onstalled='value' onsubmit='value' onsuspend='value'
+  ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
+  class='value' contenteditable='value' contextmenu='value' data-something='value'
+  dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
+  tabindex='value' title='value' prop:from='value'>
+</some-element>

--- a/src/templates/can-stache/attr-from-output.stache
+++ b/src/templates/can-stache/attr-from-output.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop:from='value'>
+  tabindex='value' title='value' prop:bind='value'>
 </some-element>

--- a/src/templates/can-stache/attr-from-test.js
+++ b/src/templates/can-stache/attr-from-test.js
@@ -1,0 +1,18 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-stache/attr-from.js';
+})[0];
+
+describe('can-stache attr to attr:from transform', function() {
+
+  it('converts `prop="value"` to `prop:from="value"` when not a global element attr', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/templates/can-stache/attr-from.js
+++ b/src/templates/can-stache/attr-from.js
@@ -1,4 +1,18 @@
-import stache from 'can-stache';
+
+const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
+  'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough',
+  'onchange', 'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick',
+  'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave', 'ondragover',
+  'ondragstart', 'ondrop', 'ondurationchange', 'onemptied', 'onended', 'onerror',
+  'onfocus', 'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup',
+  'onload', 'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown',
+  'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover',
+  'onmouseup', 'onmousewheel', 'onpause', 'onplay', 'onplaying', 'onprogress',
+  'onratechange', 'onreset', 'onresize', 'onscroll', 'onseeked', 'onseeking',
+  'onselect', 'onshow', 'onsort', 'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate',
+  'ontoggle', 'onvolumechange', 'onwaiting', 'accesskey', 'class', 'contenteditable',
+  'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style',
+  'tabindex', 'title'];
 
 export default function transformer(file) {
   let src = file.source;
@@ -6,11 +20,17 @@ export default function transformer(file) {
   var type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
-    var renderer = stache(src);
-    debugger;
+    const alphaNumeric = 'A-Za-z0-9';
+    const alphaNumericHU = '-:_'+alphaNumeric;
+    const attributeRegexp = new RegExp("["+alphaNumericHU+"]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    const attributes = src.match(attributeRegexp);
+    for (let i = 0; i < attributes.length; i++) {
+      const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+        src = src.replace(attribute, attribute + ':bind');
+      }
+    }
   }
-
-  // src = src.replace('%index', 'scope.index');
 
   return src;
 }

--- a/src/templates/can-stache/attr-from.js
+++ b/src/templates/can-stache/attr-from.js
@@ -1,0 +1,16 @@
+import stache from 'can-stache';
+
+export default function transformer(file) {
+  let src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+
+  if (type === 'stache') {
+    var renderer = stache(src);
+    debugger;
+  }
+
+  // src = src.replace('%index', 'scope.index');
+
+  return src;
+}

--- a/src/transforms/version-4/can-stache/attr-from-test.js
+++ b/src/transforms/version-4/can-stache/attr-from-test.js
@@ -1,0 +1,18 @@
+
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-stache/attr-from.js';
+})[0];
+
+describe('can-stache attr to attr:from transform', function() {
+
+  it('converts `prop="value"` to `prop:from="value"` when not a global element attr', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.stache')}`;
+    const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.stache')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/transforms/version-4/can-stache/attr-from.js
+++ b/src/transforms/version-4/can-stache/attr-from.js
@@ -1,4 +1,18 @@
-import stache from 'can-stache';
+
+const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
+  'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough',
+  'onchange', 'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick',
+  'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave', 'ondragover',
+  'ondragstart', 'ondrop', 'ondurationchange', 'onemptied', 'onended', 'onerror',
+  'onfocus', 'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup',
+  'onload', 'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown',
+  'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover',
+  'onmouseup', 'onmousewheel', 'onpause', 'onplay', 'onplaying', 'onprogress',
+  'onratechange', 'onreset', 'onresize', 'onscroll', 'onseeked', 'onseeking',
+  'onselect', 'onshow', 'onsort', 'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate',
+  'ontoggle', 'onvolumechange', 'onwaiting', 'accesskey', 'class', 'contenteditable',
+  'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style',
+  'tabindex', 'title'];
 
 export default function transformer(file) {
   let src = file.source;
@@ -6,11 +20,17 @@ export default function transformer(file) {
   var type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
-    var renderer = stache(src);
-    debugger;
+    const alphaNumeric = 'A-Za-z0-9';
+    const alphaNumericHU = '-:_'+alphaNumeric;
+    const attributeRegexp = new RegExp("["+alphaNumericHU+"]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    const attributes = src.match(attributeRegexp);
+    for (let i = 0; i < attributes.length; i++) {
+      const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+        src = src.replace(attribute, attribute + ':bind');
+      }
+    }
   }
-
-  // src = src.replace('%index', 'scope.index');
 
   return src;
 }

--- a/src/transforms/version-4/can-stache/attr-from.js
+++ b/src/transforms/version-4/can-stache/attr-from.js
@@ -1,0 +1,16 @@
+import stache from 'can-stache';
+
+export default function transformer(file) {
+  let src = file.source;
+  var path = file.path;
+  var type = path.slice(path.lastIndexOf('.') + 1);
+
+  if (type === 'stache') {
+    var renderer = stache(src);
+    debugger;
+  }
+
+  // src = src.replace('%index', 'scope.index');
+
+  return src;
+}

--- a/test/fixtures/version-4/can-stache/attr-from-input.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-input.stache
@@ -1,0 +1,18 @@
+<some-element xml:lang='value' xml:base='value' aria-labelledby='value' onabort='value'
+  onautocomplete='value' onautocompleteerror='value' onblur='value' oncancel='value'
+  oncanplay='value' oncanplaythrough='value' onchange='value' onclick='value' onclose='value'
+  oncontextmenu='value' oncuechange='value' ondblclick='value' ondrag='value' ondragend='value'
+  ondragenter='value' ondragexit='value' ondragleave='value' ondragover='value' ondragstart='value'
+  ondrop='value' ondurationchange='value' onemptied='value' onended='value' onerror='value'
+  onfocus='value' oninput='value' oninvalid='value' onkeydown='value' onkeypress='value'
+  onkeyup='value' onload='value' onloadeddata='value' onloadedmetadata='value' onloadstart='value'
+  onmousedown='value' onmouseenter='value' onmouseleave='value' onmousemove='value'
+  onmouseout='value' onmouseover='value' onmouseup='value' onmousewheel='value' onpause='value'
+  onplay='value' onplaying='value' onprogress='value' onratechange='value' onreset='value'
+  onresize='value' onscroll='value' onseeked='value' onseeking='value' onselect='value'
+  onshow='value' onsort='value' onstalled='value' onsubmit='value' onsuspend='value'
+  ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
+  class='value' contenteditable='value' contextmenu='value' data-something='value'
+  dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
+  tabindex='value' title='value' prop='value'>
+</some-element>

--- a/test/fixtures/version-4/can-stache/attr-from-output.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-output.stache
@@ -1,0 +1,18 @@
+<some-element xml:lang='value' xml:base='value' aria-labelledby='value' onabort='value'
+  onautocomplete='value' onautocompleteerror='value' onblur='value' oncancel='value'
+  oncanplay='value' oncanplaythrough='value' onchange='value' onclick='value' onclose='value'
+  oncontextmenu='value' oncuechange='value' ondblclick='value' ondrag='value' ondragend='value'
+  ondragenter='value' ondragexit='value' ondragleave='value' ondragover='value' ondragstart='value'
+  ondrop='value' ondurationchange='value' onemptied='value' onended='value' onerror='value'
+  onfocus='value' oninput='value' oninvalid='value' onkeydown='value' onkeypress='value'
+  onkeyup='value' onload='value' onloadeddata='value' onloadedmetadata='value' onloadstart='value'
+  onmousedown='value' onmouseenter='value' onmouseleave='value' onmousemove='value'
+  onmouseout='value' onmouseover='value' onmouseup='value' onmousewheel='value' onpause='value'
+  onplay='value' onplaying='value' onprogress='value' onratechange='value' onreset='value'
+  onresize='value' onscroll='value' onseeked='value' onseeking='value' onselect='value'
+  onshow='value' onsort='value' onstalled='value' onsubmit='value' onsuspend='value'
+  ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
+  class='value' contenteditable='value' contextmenu='value' data-something='value'
+  dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
+  tabindex='value' title='value' prop:from='value'>
+</some-element>

--- a/test/fixtures/version-4/can-stache/attr-from-output.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-output.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop:from='value'>
+  tabindex='value' title='value' prop:bind='value'>
 </some-element>

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ require('../lib/transforms/version-4/can-stache/route-helpers-test.js');
 require('../lib/transforms/version-4/can-stache/console-log-test.js');
 require('../lib/transforms/version-4/can-define/default-test.js');
 require('../lib/transforms/version-4/can-define/for-each-test.js');
+require('../lib/transforms/version-4/can-stache/attr-from-test.js');
 require('../lib/transforms/version-3/can-component/import-test.js');
 require('../lib/transforms/version-3/can-construct/import-test.js');
 require('../lib/transforms/version-3/can-construct-super/import-test.js');


### PR DESCRIPTION
This adds a codemod that will look for any attributes on an element that are not global HTML element attributes and will change them to be bound to the viewModel like:
`prop='some value'` => `prop:bind='some value'`