### PR TITLE
Changed bind to from and added quotes

### DIFF
--- a/lib/transforms/version-4/can-stache/attr-from.js
+++ b/lib/transforms/version-4/can-stache/attr-from.js
@@ -19,8 +19,15 @@ function transformer(file) {
     var attributes = src.match(attributeRegexp);
     for (var i = 0; i < attributes.length; i++) {
       var attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      var value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
       if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
-        src = src.replace(attribute, attribute + ':bind');
+        src = src.replace(attribute, attribute + ':from');
+        if (value.includes("'")) {
+          // jshint ignore:line
+          src = src.replace(value, '"' + value + '"'); // jshint ignore:line
+        } else {
+          src = src.replace(value, "'" + value + "'"); // jshint ignore:line
+        }
       }
     }
   }

--- a/src/templates/can-stache/attr-from-input.stache
+++ b/src/templates/can-stache/attr-from-input.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop='value'>
+  tabindex='value' title='value' prop='something' prop2="something else">
 </some-element>

--- a/src/templates/can-stache/attr-from-output.stache
+++ b/src/templates/can-stache/attr-from-output.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop:bind='value'>
+  tabindex='value' title='value' prop:from="'something'" prop2:from='"something else"'>
 </some-element>

--- a/src/templates/can-stache/attr-from.js
+++ b/src/templates/can-stache/attr-from.js
@@ -26,8 +26,15 @@ export default function transformer(file) {
     const attributes = src.match(attributeRegexp);
     for (let i = 0; i < attributes.length; i++) {
       const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      const value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
       if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
-        src = src.replace(attribute, attribute + ':bind');
+        src = src.replace(attribute, attribute + ':from');
+        if (value.includes("'")) { // jshint ignore:line
+          src = src.replace(value, '"' + value + '"'); // jshint ignore:line
+        }
+        else {
+          src = src.replace(value, "'" + value + "'"); // jshint ignore:line
+        }
       }
     }
   }

--- a/src/transforms/version-4/can-stache/attr-from.js
+++ b/src/transforms/version-4/can-stache/attr-from.js
@@ -26,8 +26,15 @@ export default function transformer(file) {
     const attributes = src.match(attributeRegexp);
     for (let i = 0; i < attributes.length; i++) {
       const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
+      const value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
       if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
-        src = src.replace(attribute, attribute + ':bind');
+        src = src.replace(attribute, attribute + ':from');
+        if (value.includes("'")) { // jshint ignore:line
+          src = src.replace(value, '"' + value + '"'); // jshint ignore:line
+        }
+        else {
+          src = src.replace(value, "'" + value + "'"); // jshint ignore:line
+        }
       }
     }
   }

--- a/test/fixtures/version-4/can-stache/attr-from-input.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-input.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop='value'>
+  tabindex='value' title='value' prop='something' prop2="something else">
 </some-element>

--- a/test/fixtures/version-4/can-stache/attr-from-output.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-output.stache
@@ -14,5 +14,5 @@
   ontimeupdate='value' ontoggle='value' onvolumechange='value' onwaiting='value' accesskey='value'
   class='value' contenteditable='value' contextmenu='value' data-something='value'
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
-  tabindex='value' title='value' prop:bind='value'>
+  tabindex='value' title='value' prop:from="'something'" prop2:from='"something else"'>
 </some-element>


### PR DESCRIPTION
Based on conversation with Kevin we are using `:from` instead of `:bind` for the `prop="value"` to `prop:from="'value'"` codemod.

This will also add the opposite type of quotes to the element attr so that it is always passed as a string.