### PR TITLE
Fixing false positives with attr-from codemod

### DIFF
--- a/lib/transforms/version-4/can-stache/attr-from.js
+++ b/lib/transforms/version-4/can-stache/attr-from.js
@@ -5,7 +5,38 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = transformer;
 
+var _canViewParser = require('can-view-parser');
+
+var _canViewParser2 = _interopRequireDefault(_canViewParser);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete', 'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange', 'onclick', 'onclose', 'oncontextmenu', 'oncuechange', 'ondblclick', 'ondrag', 'ondragend', 'ondragenter', 'ondragexit', 'ondragleave', 'ondragover', 'ondragstart', 'ondrop', 'ondurationchange', 'onemptied', 'onended', 'onerror', 'onfocus', 'oninput', 'oninvalid', 'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onloadeddata', 'onloadedmetadata', 'onloadstart', 'onmousedown', 'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onmousewheel', 'onpause', 'onplay', 'onplaying', 'onprogress', 'onratechange', 'onreset', 'onresize', 'onscroll', 'onseeked', 'onseeking', 'onselect', 'onshow', 'onsort', 'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle', 'onvolumechange', 'onwaiting', 'accesskey', 'class', 'contenteditable', 'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style', 'tabindex', 'title'];
+
+var noop = function noop() {};
+
+var isDataAttribute = function isDataAttribute(attributeName) {
+  return attributeName.indexOf('data-') === 0;
+};
+var isAriaAttribute = function isAriaAttribute(attributeName) {
+  return attributeName.indexOf('aria-') === 0;
+};
+var isInGlobalAttributes = function isInGlobalAttributes(attributeName) {
+  return globalAttributes.indexOf(attributeName) >= 0;
+};
+var attributeShouldBeModified = function attributeShouldBeModified(attributeName) {
+  return !isDataAttribute(attributeName) && !isAriaAttribute(attributeName) && !isInGlobalAttributes(attributeName);
+};
+
+var isCustomElement = function isCustomElement(tagName) {
+  return tagName.includes('-');
+};
+var isCanElement = function isCanElement(tagName) {
+  return tagName.indexOf('can-') === 0;
+};
+var tagShouldBeModified = function tagShouldBeModified(tagName) {
+  return isCustomElement(tagName) && !isCanElement(tagName);
+};
 
 function transformer(file) {
   var src = file.source;
@@ -13,14 +44,43 @@ function transformer(file) {
   var type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
+    // this list contains a boolean for each attribute found during parsing to indicate
+    // whether its value should be modified when looping through attributes with regex
+    var attributeAtIndexShouldBeModified = [];
+
+    var currentTag = '';
+    var currentAttr = '';
+
+    (0, _canViewParser2.default)(src, {
+      start: function start(tagName) {
+        currentTag = tagName;
+      },
+      end: function end() {
+        currentTag = '';
+      },
+      attrStart: function attrStart(attrName) {
+        currentAttr = attrName;
+      },
+      attrEnd: function attrEnd() {
+        currentAttr = '';
+      },
+      attrValue: function attrValue() {
+        var shouldModify = tagShouldBeModified(currentTag) && attributeShouldBeModified(currentAttr);
+        attributeAtIndexShouldBeModified.push(shouldModify);
+      },
+      done: noop,
+      special: noop
+    });
+
     var alphaNumeric = 'A-Za-z0-9';
     var alphaNumericHU = '-:_' + alphaNumeric;
-    var attributeRegexp = new RegExp("[" + alphaNumericHU + "]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    var attributeRegexp = new RegExp('[' + alphaNumericHU + ']+\s*=\s*("[^"]*"|\'[^\']*\')', 'gm');
     var attributes = src.match(attributeRegexp);
+
     for (var i = 0; i < attributes.length; i++) {
       var attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
       var value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
-      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+      if (attributeAtIndexShouldBeModified[i]) {
         src = src.replace(attribute, attribute + ':from');
         if (value.includes("'")) {
           // jshint ignore:line

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/canjs/can-migrate#readme",
   "dependencies": {
+    "can-view-parser": "^4.0.2",
     "deep-assign": "^2.0.0",
     "disparity": "^2.0.0",
     "execa": "^0.9.0",

--- a/src/templates/can-stache/attr-from-input.stache
+++ b/src/templates/can-stache/attr-from-input.stache
@@ -16,3 +16,5 @@
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
   tabindex='value' title='value' prop='something' prop2="something else">
 </some-element>
+<can-import from="some/thing"/>
+<script src="{{joinBase 'steal.production.js'}}"></script>

--- a/src/templates/can-stache/attr-from-output.stache
+++ b/src/templates/can-stache/attr-from-output.stache
@@ -16,3 +16,5 @@
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
   tabindex='value' title='value' prop:from="'something'" prop2:from='"something else"'>
 </some-element>
+<can-import from="some/thing"/>
+<script src="{{joinBase 'steal.production.js'}}"></script>

--- a/src/templates/can-stache/attr-from.js
+++ b/src/templates/can-stache/attr-from.js
@@ -1,3 +1,4 @@
+import parser from 'can-view-parser';
 
 const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
   'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough',
@@ -14,25 +15,70 @@ const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
   'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style',
   'tabindex', 'title'];
 
+const noop = function() {};
+
+const isDataAttribute = (attributeName) => attributeName.indexOf('data-') === 0;
+const isAriaAttribute = (attributeName) => attributeName.indexOf('aria-') === 0;
+const isInGlobalAttributes = (attributeName) => globalAttributes.indexOf(attributeName) >= 0;
+const attributeShouldBeModified = (attributeName) =>
+  !isDataAttribute(attributeName) &&
+  !isAriaAttribute(attributeName) &&
+  !isInGlobalAttributes(attributeName);
+
+const isCustomElement = (tagName) => tagName.includes('-');
+const isCanElement = (tagName) => tagName.indexOf('can-') === 0;
+const tagShouldBeModified = (tagName) =>
+  isCustomElement(tagName) &&
+  !isCanElement(tagName);
+
 export default function transformer(file) {
   let src = file.source;
-  var path = file.path;
-  var type = path.slice(path.lastIndexOf('.') + 1);
+  const path = file.path;
+  const type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
+    // this list contains a boolean for each attribute found during parsing to indicate
+    // whether its value should be modified when looping through attributes with regex
+    let attributeAtIndexShouldBeModified = [];
+
+    let currentTag = '';
+    let currentAttr = '';
+
+    parser(src, {
+      start: function(tagName) {
+        currentTag = tagName;
+      },
+      end: function() {
+        currentTag = '';
+      },
+      attrStart: function(attrName) {
+        currentAttr = attrName;
+      },
+      attrEnd: function() {
+        currentAttr = '';
+      },
+      attrValue: function() {
+        const shouldModify = tagShouldBeModified(currentTag) &&
+          attributeShouldBeModified(currentAttr);
+        attributeAtIndexShouldBeModified.push(shouldModify);
+      },
+      done: noop,
+      special: noop
+    });
+
     const alphaNumeric = 'A-Za-z0-9';
-    const alphaNumericHU = '-:_'+alphaNumeric;
-    const attributeRegexp = new RegExp("["+alphaNumericHU+"]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    const alphaNumericHU = '-:_' + alphaNumeric;
+    const attributeRegexp = new RegExp('[' + alphaNumericHU + ']+\s*=\s*("[^"]*"|\'[^\']*\')', 'gm');
     const attributes = src.match(attributeRegexp);
+
     for (let i = 0; i < attributes.length; i++) {
       const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
       const value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
-      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+      if (attributeAtIndexShouldBeModified[i]) {
         src = src.replace(attribute, attribute + ':from');
         if (value.includes("'")) { // jshint ignore:line
           src = src.replace(value, '"' + value + '"'); // jshint ignore:line
-        }
-        else {
+        } else {
           src = src.replace(value, "'" + value + "'"); // jshint ignore:line
         }
       }

--- a/src/transforms/version-4/can-stache/attr-from.js
+++ b/src/transforms/version-4/can-stache/attr-from.js
@@ -1,3 +1,4 @@
+import parser from 'can-view-parser';
 
 const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
   'onautocompleteerror', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough',
@@ -14,25 +15,70 @@ const globalAttributes = ['xml:lang', 'xml:base', 'onabort', 'onautocomplete',
   'contextmenu', 'dir', 'draggable', 'hidden', 'id', 'is', 'lang', 'style',
   'tabindex', 'title'];
 
+const noop = function() {};
+
+const isDataAttribute = (attributeName) => attributeName.indexOf('data-') === 0;
+const isAriaAttribute = (attributeName) => attributeName.indexOf('aria-') === 0;
+const isInGlobalAttributes = (attributeName) => globalAttributes.indexOf(attributeName) >= 0;
+const attributeShouldBeModified = (attributeName) =>
+  !isDataAttribute(attributeName) &&
+  !isAriaAttribute(attributeName) &&
+  !isInGlobalAttributes(attributeName);
+
+const isCustomElement = (tagName) => tagName.includes('-');
+const isCanElement = (tagName) => tagName.indexOf('can-') === 0;
+const tagShouldBeModified = (tagName) =>
+  isCustomElement(tagName) &&
+  !isCanElement(tagName);
+
 export default function transformer(file) {
   let src = file.source;
-  var path = file.path;
-  var type = path.slice(path.lastIndexOf('.') + 1);
+  const path = file.path;
+  const type = path.slice(path.lastIndexOf('.') + 1);
 
   if (type === 'stache') {
+    // this list contains a boolean for each attribute found during parsing to indicate
+    // whether its value should be modified when looping through attributes with regex
+    let attributeAtIndexShouldBeModified = [];
+
+    let currentTag = '';
+    let currentAttr = '';
+
+    parser(src, {
+      start: function(tagName) {
+        currentTag = tagName;
+      },
+      end: function() {
+        currentTag = '';
+      },
+      attrStart: function(attrName) {
+        currentAttr = attrName;
+      },
+      attrEnd: function() {
+        currentAttr = '';
+      },
+      attrValue: function() {
+        const shouldModify = tagShouldBeModified(currentTag) &&
+          attributeShouldBeModified(currentAttr);
+        attributeAtIndexShouldBeModified.push(shouldModify);
+      },
+      done: noop,
+      special: noop
+    });
+
     const alphaNumeric = 'A-Za-z0-9';
-    const alphaNumericHU = '-:_'+alphaNumeric;
-    const attributeRegexp = new RegExp("["+alphaNumericHU+"]+\s*=\s*(\"[^\"]*\"|'[^']*')", 'gm'); // jshint ignore:line
+    const alphaNumericHU = '-:_' + alphaNumeric;
+    const attributeRegexp = new RegExp('[' + alphaNumericHU + ']+\s*=\s*("[^"]*"|\'[^\']*\')', 'gm');
     const attributes = src.match(attributeRegexp);
+
     for (let i = 0; i < attributes.length; i++) {
       const attribute = attributes[i].slice(0, attributes[i].lastIndexOf('='));
       const value = attributes[i].slice(attributes[i].lastIndexOf('=') + 1);
-      if (globalAttributes.indexOf(attribute) === -1 && !attribute.includes('aria') && !attribute.includes('data')) {
+      if (attributeAtIndexShouldBeModified[i]) {
         src = src.replace(attribute, attribute + ':from');
         if (value.includes("'")) { // jshint ignore:line
           src = src.replace(value, '"' + value + '"'); // jshint ignore:line
-        }
-        else {
+        } else {
           src = src.replace(value, "'" + value + "'"); // jshint ignore:line
         }
       }

--- a/test/fixtures/version-4/can-stache/attr-from-input.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-input.stache
@@ -16,3 +16,5 @@
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
   tabindex='value' title='value' prop='something' prop2="something else">
 </some-element>
+<can-import from="some/thing"/>
+<script src="{{joinBase 'steal.production.js'}}"></script>

--- a/test/fixtures/version-4/can-stache/attr-from-output.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-output.stache
@@ -16,3 +16,5 @@
   dir='value' draggable='value' hidden='value' id='value' is='value' lang='value' style='value'
   tabindex='value' title='value' prop:from="'something'" prop2:from='"something else"'>
 </some-element>
+<can-import from="some/thing"/>
+<script src="{{joinBase 'steal.production.js'}}"></script>


### PR DESCRIPTION
closes https://github.com/canjs/can-migrate/issues/71.

This change restricts the attr-from codemod to attributes:

* on custom elements
* that don't start with `can-`
* that are not `aria-` or `data-` attributes
* and are in the `globalAttributes` list