### PR TITLE
Fixing value->default false positives

### DIFF
--- a/lib/transforms/version-4/can-define/default-test.js
+++ b/lib/transforms/version-4/can-define/default-test.js
@@ -9,7 +9,7 @@ var toTest = transforms.filter(function (transform) {
 })[0];
 
 describe('can-define default transform', function () {
-  it('converts `value` to `default` only in DefineMap extends', function () {
+  it('converts `value` to `default` only in DefineMap.extends PropDefinitions', function () {
     var fn = require(toTest.file);
     var inputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-input.js');
     var outputPath = 'fixtures/version-4/' + toTest.fileName.replace('.js', '-output.js');

--- a/lib/transforms/version-4/can-define/default.js
+++ b/lib/transforms/version-4/can-define/default.js
@@ -14,9 +14,17 @@ function transformer(file, api) {
         name: 'DefineMap'
       }
     }
-  }).forEach(function (expressionStatement) {
-    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(function (identifier) {
-      identifier.node.name = 'default';
+  }).forEach(function (path) {
+    // loop through each PropDefinition
+    // passed to the first argument of DefineMap.extend
+    path.value.arguments[0].properties.forEach(function (propDefinition) {
+      if (propDefinition.value.type === 'ObjectExpression') {
+        propDefinition.value.properties.forEach(function (behavior) {
+          if (behavior.key.name === 'value') {
+            behavior.key.name = 'default';
+          }
+        });
+      }
     });
   }).toSource();
 }

--- a/src/templates/can-define/default-input.js
+++ b/src/templates/can-define/default-input.js
@@ -1,5 +1,23 @@
-
 let ViewModel = DefineMap.extend({
+  myProp: {
+    value: 'something'
+  },
+  myOtherProp: {
+    set(value) {
+      return value;
+    }
+  },
+  myFunc(el) {
+    return el.value
+  },
+  myFunc2(el) {
+    return {
+      value: el.value
+    };
+  }
+});
+
+let ViewModel = new DefineMap({
   myProp: {
     value: 'something'
   }

--- a/src/templates/can-define/default-output.js
+++ b/src/templates/can-define/default-output.js
@@ -1,7 +1,25 @@
-
 let ViewModel = DefineMap.extend({
   myProp: {
     default: 'something'
+  },
+  myOtherProp: {
+    set(value) {
+      return value;
+    }
+  },
+  myFunc(el) {
+    return el.value
+  },
+  myFunc2(el) {
+    return {
+      value: el.value
+    };
+  }
+});
+
+let ViewModel = new DefineMap({
+  myProp: {
+    value: 'something'
   }
 });
 

--- a/src/templates/can-define/default-test.js
+++ b/src/templates/can-define/default-test.js
@@ -8,7 +8,7 @@ const toTest = transforms.filter(function(transform) {
 })[0];
 
 describe('can-define default transform', function() {
-  it('converts `value` to `default` only in DefineMap extends', function() {
+  it('converts `value` to `default` only in DefineMap.extends PropDefinitions', function() {
     const fn = require(toTest.file);
     const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.js')}`;
     const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.js')}`;

--- a/src/templates/can-define/default.js
+++ b/src/templates/can-define/default.js
@@ -2,15 +2,27 @@ export default function transformer(file, api) {
   let j = api.jscodeshift;
   let root = j(file.source);
 
-  return root.find(j.CallExpression, {
-    callee: {
-      object: {
-        name: 'DefineMap'
+  return root
+    .find(j.CallExpression, {
+      callee: {
+        object: {
+          name: 'DefineMap'
+        }
       }
-    }
-  }).forEach(expressionStatement => {
-    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(identifier => {
-      identifier.node.name = 'default';
-    });
-  }).toSource();
+    })
+    .forEach((path) => {
+      // loop through each PropDefinition
+      // passed to the first argument of DefineMap.extend
+      path.value.arguments[0].properties
+        .forEach((propDefinition) => {
+          if (propDefinition.value.type === 'ObjectExpression') {
+            propDefinition.value.properties
+              .forEach((behavior) => {
+                if (behavior.key.name === 'value') {
+                  behavior.key.name = 'default';
+                }
+              });
+          }
+        });
+    }).toSource();
 }

--- a/src/transforms/version-4/can-define/default-test.js
+++ b/src/transforms/version-4/can-define/default-test.js
@@ -8,7 +8,7 @@ const toTest = transforms.filter(function(transform) {
 })[0];
 
 describe('can-define default transform', function() {
-  it('converts `value` to `default` only in DefineMap extends', function() {
+  it('converts `value` to `default` only in DefineMap.extends PropDefinitions', function() {
     const fn = require(toTest.file);
     const inputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-input.js')}`;
     const outputPath = `fixtures/version-4/${toTest.fileName.replace('.js', '-output.js')}`;

--- a/src/transforms/version-4/can-define/default.js
+++ b/src/transforms/version-4/can-define/default.js
@@ -2,15 +2,27 @@ export default function transformer(file, api) {
   let j = api.jscodeshift;
   let root = j(file.source);
 
-  return root.find(j.CallExpression, {
-    callee: {
-      object: {
-        name: 'DefineMap'
+  return root
+    .find(j.CallExpression, {
+      callee: {
+        object: {
+          name: 'DefineMap'
+        }
       }
-    }
-  }).forEach(expressionStatement => {
-    j(expressionStatement).find(j.Identifier, { name: 'value' }).forEach(identifier => {
-      identifier.node.name = 'default';
-    });
-  }).toSource();
+    })
+    .forEach((path) => {
+      // loop through each PropDefinition
+      // passed to the first argument of DefineMap.extend
+      path.value.arguments[0].properties
+        .forEach((propDefinition) => {
+          if (propDefinition.value.type === 'ObjectExpression') {
+            propDefinition.value.properties
+              .forEach((behavior) => {
+                if (behavior.key.name === 'value') {
+                  behavior.key.name = 'default';
+                }
+              });
+          }
+        });
+    }).toSource();
 }

--- a/test/fixtures/version-4/can-define/default-input.js
+++ b/test/fixtures/version-4/can-define/default-input.js
@@ -1,5 +1,23 @@
-
 let ViewModel = DefineMap.extend({
+  myProp: {
+    value: 'something'
+  },
+  myOtherProp: {
+    set(value) {
+      return value;
+    }
+  },
+  myFunc(el) {
+    return el.value
+  },
+  myFunc2(el) {
+    return {
+      value: el.value
+    };
+  }
+});
+
+let ViewModel = new DefineMap({
   myProp: {
     value: 'something'
   }

--- a/test/fixtures/version-4/can-define/default-output.js
+++ b/test/fixtures/version-4/can-define/default-output.js
@@ -1,7 +1,25 @@
-
 let ViewModel = DefineMap.extend({
   myProp: {
     default: 'something'
+  },
+  myOtherProp: {
+    set(value) {
+      return value;
+    }
+  },
+  myFunc(el) {
+    return el.value
+  },
+  myFunc2(el) {
+    return {
+      value: el.value
+    };
+  }
+});
+
+let ViewModel = new DefineMap({
+  myProp: {
+    value: 'something'
   }
 });
 


### PR DESCRIPTION
This makes sure `value` is only changed to `default` if it is a key
directly on a PropDefinition passed to DefineMap.extend.

closes https://github.com/canjs/can-migrate/issues/83.