### PR TITLE
not running attr-from codemod on attributes that are already bindings

### DIFF
--- a/lib/transforms/version-4/can-stache/attr-from.js
+++ b/lib/transforms/version-4/can-stache/attr-from.js
@@ -21,11 +21,14 @@ var isDataAttribute = function isDataAttribute(attributeName) {
 var isAriaAttribute = function isAriaAttribute(attributeName) {
   return attributeName.indexOf('aria-') === 0;
 };
+var isBindingAttribute = function isBindingAttribute(attributeName) {
+  return attributeName.startsWith('on:') || attributeName.endsWith(':to') || attributeName.endsWith(':from') || attributeName.endsWith(':bind');
+};
 var isInGlobalAttributes = function isInGlobalAttributes(attributeName) {
   return globalAttributes.indexOf(attributeName) >= 0;
 };
 var attributeShouldBeModified = function attributeShouldBeModified(attributeName) {
-  return !isDataAttribute(attributeName) && !isAriaAttribute(attributeName) && !isInGlobalAttributes(attributeName);
+  return !isDataAttribute(attributeName) && !isAriaAttribute(attributeName) && !isBindingAttribute(attributeName) && !isInGlobalAttributes(attributeName);
 };
 
 var isCustomElement = function isCustomElement(tagName) {

--- a/src/templates/can-stache/attr-from-input.stache
+++ b/src/templates/can-stache/attr-from-input.stache
@@ -21,4 +21,4 @@
 <h4>
   <a href="{{routeUrl page='home'}}">Home</a>
 </h4>
-<another-element prop3="something"/>
+<another-element prop3="something" on:click="setFoo()" prop4:from="foo" prop5:to="bar" prop5:bind="baz" />

--- a/src/templates/can-stache/attr-from-output.stache
+++ b/src/templates/can-stache/attr-from-output.stache
@@ -21,4 +21,4 @@
 <h4>
   <a href="{{routeUrl page='home'}}">Home</a>
 </h4>
-<another-element prop3:from='"something"'/>
+<another-element prop3:from='"something"' on:click="setFoo()" prop4:from="foo" prop5:to="bar" prop5:bind="baz" />

--- a/src/templates/can-stache/attr-from.js
+++ b/src/templates/can-stache/attr-from.js
@@ -19,10 +19,16 @@ const noop = function() {};
 
 const isDataAttribute = (attributeName) => attributeName.indexOf('data-') === 0;
 const isAriaAttribute = (attributeName) => attributeName.indexOf('aria-') === 0;
+const isBindingAttribute = (attributeName) =>
+  attributeName.startsWith('on:') ||
+  attributeName.endsWith(':to') ||
+  attributeName.endsWith(':from') ||
+  attributeName.endsWith(':bind');
 const isInGlobalAttributes = (attributeName) => globalAttributes.indexOf(attributeName) >= 0;
 const attributeShouldBeModified = (attributeName) =>
   !isDataAttribute(attributeName) &&
   !isAriaAttribute(attributeName) &&
+  !isBindingAttribute(attributeName) &&
   !isInGlobalAttributes(attributeName);
 
 const isCustomElement = (tagName) => tagName.includes('-');

--- a/src/transforms/version-4/can-stache/attr-from.js
+++ b/src/transforms/version-4/can-stache/attr-from.js
@@ -19,10 +19,16 @@ const noop = function() {};
 
 const isDataAttribute = (attributeName) => attributeName.indexOf('data-') === 0;
 const isAriaAttribute = (attributeName) => attributeName.indexOf('aria-') === 0;
+const isBindingAttribute = (attributeName) =>
+  attributeName.startsWith('on:') ||
+  attributeName.endsWith(':to') ||
+  attributeName.endsWith(':from') ||
+  attributeName.endsWith(':bind');
 const isInGlobalAttributes = (attributeName) => globalAttributes.indexOf(attributeName) >= 0;
 const attributeShouldBeModified = (attributeName) =>
   !isDataAttribute(attributeName) &&
   !isAriaAttribute(attributeName) &&
+  !isBindingAttribute(attributeName) &&
   !isInGlobalAttributes(attributeName);
 
 const isCustomElement = (tagName) => tagName.includes('-');

--- a/test/fixtures/version-4/can-stache/attr-from-input.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-input.stache
@@ -21,4 +21,4 @@
 <h4>
   <a href="{{routeUrl page='home'}}">Home</a>
 </h4>
-<another-element prop3="something"/>
+<another-element prop3="something" on:click="setFoo()" prop4:from="foo" prop5:to="bar" prop5:bind="baz" />

--- a/test/fixtures/version-4/can-stache/attr-from-output.stache
+++ b/test/fixtures/version-4/can-stache/attr-from-output.stache
@@ -21,4 +21,4 @@
 <h4>
   <a href="{{routeUrl page='home'}}">Home</a>
 </h4>
-<another-element prop3:from='"something"'/>
+<another-element prop3:from='"something"' on:click="setFoo()" prop4:from="foo" prop5:to="bar" prop5:bind="baz" />


### PR DESCRIPTION
closes https://github.com/canjs/can-migrate/issues/82.