### PR TITLE
not writing files that have not changed

### DIFF
--- a/lib/utils/runTransform.js
+++ b/lib/utils/runTransform.js
@@ -53,7 +53,7 @@ function runTransform(transform, paths, args, apply) {
     var options = {};
     var newSource = transformFunc(file, mockApi, options);
     // Write changes to file if apply specified
-    if (apply) {
+    if (newSource !== file.source && apply) {
       fs.writeFileSync(file.path, newSource);
     }
   }

--- a/src/utils/runTransform.js
+++ b/src/utils/runTransform.js
@@ -45,7 +45,9 @@ function runTransform(transform, paths, args, apply) {
     let options = {};
     let newSource = transformFunc(file, mockApi, options);
     // Write changes to file if apply specified
-    if (apply) { fs.writeFileSync(file.path, newSource); }
+    if (newSource !== file.source && apply) {
+      fs.writeFileSync(file.path, newSource);
+    }
   }
 
   args = args.concat(jsPaths);


### PR DESCRIPTION
Calling `fs.writeFile` on files that have not changed causes images and
other binary files to look like they have changed in git. This is
annoying, so this is being prevented.