### PR TITLE
converting property value shorthand for `template` to non-shorthand before renaming

### DIFF
--- a/lib/transforms/version-3/can-component-rename/can-component-rename.js
+++ b/lib/transforms/version-3/can-component-rename/can-component-rename.js
@@ -38,15 +38,35 @@ function transformer(file, api, options) {
     }
   }).forEach(function (expression) {
     var eventsProp = _propertyUtils2.default.find(expression.value.arguments[0], 'events');
-    var leakScope = _propertyUtils2.default.find(expression.value.arguments[0], 'leakScope');
+    var leakScopeProp = _propertyUtils2.default.find(expression.value.arguments[0], 'leakScope');
+    var templateProp = _propertyUtils2.default.find(expression.value.arguments[0], 'template');
 
     debug('Adding leakScope: true');
-    if (!leakScope) {
+    if (!leakScopeProp) {
       expression.value.arguments[0].properties.push(leakScopeTrue);
+    }
+
+    // change `template` property value shorthand:
+    //
+    // .extend({
+    //   template
+    // })
+    //
+    // to non-shorthand:
+    //
+    // .extend({
+    //   template: template
+    // })
+    //
+    // before renaming to view
+    if (templateProp && templateProp.shorthand === true) {
+      debug('Changing property value shorthand for \'template\' to \'template: template\'');
+      templateProp.shorthand = false;
     }
 
     debug('Renaming \'template\' -> \'view\'');
     _propertyUtils2.default.rename(expression.value.arguments[0], 'template', 'view');
+
     if (eventsProp) {
       debug('Renaming \'removed\' -> \'beforeremove\'');
       _propertyUtils2.default.rename(eventsProp.value, 'removed', '{element} beforeremove', true);

--- a/src/templates/can-component-rename/input.js
+++ b/src/templates/can-component-rename/input.js
@@ -1,3 +1,5 @@
+import template from "foo";
+
 Component.extend({
   tag: 'my-tag',
   template: 'Hi',
@@ -20,4 +22,14 @@ Component.extend({
     'removed': () => {}
   },
   leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  template: template
+});
+
+Component.extend({
+  tag: 'my-tag',
+  template
 });

--- a/src/templates/can-component-rename/output.js
+++ b/src/templates/can-component-rename/output.js
@@ -1,3 +1,5 @@
+import template from "foo";
+
 Component.extend({
   tag: 'my-tag',
   view: 'Hi',
@@ -25,5 +27,17 @@ Component.extend({
   events: {
     '{element} beforeremove': () => {}
   },
+  leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  view: template,
+  leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  view: template,
   leakScope: true
 });

--- a/test/fixtures/version-3/can-component-rename/can-component-rename-input.js
+++ b/test/fixtures/version-3/can-component-rename/can-component-rename-input.js
@@ -1,3 +1,5 @@
+import template from "foo";
+
 Component.extend({
   tag: 'my-tag',
   template: 'Hi',
@@ -20,4 +22,14 @@ Component.extend({
     'removed': () => {}
   },
   leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  template: template
+});
+
+Component.extend({
+  tag: 'my-tag',
+  template
 });

--- a/test/fixtures/version-3/can-component-rename/can-component-rename-output.js
+++ b/test/fixtures/version-3/can-component-rename/can-component-rename-output.js
@@ -1,3 +1,5 @@
+import template from "foo";
+
 Component.extend({
   tag: 'my-tag',
   view: 'Hi',
@@ -25,5 +27,17 @@ Component.extend({
   events: {
     '{element} beforeremove': () => {}
   },
+  leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  view: template,
+  leakScope: true
+});
+
+Component.extend({
+  tag: 'my-tag',
+  view: template,
   leakScope: true
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-migrate/issues/9.