### PR TITLE
fixes issue with stachelement being exported and unable to add define

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -605,14 +605,14 @@
         "order": 5
       },
       {
-        "input": "can-observable-array/import-input.js",
-        "outputPath": "can-observable-array/import-input.js",
+        "input": "can-observable-array/import-input.html",
+        "outputPath": "can-observable-array/import-input.html",
         "type": "fixture",
         "version": "6"
       },
       {
-        "input": "can-observable-array/import-output.js",
-        "outputPath": "can-observable-array/import-output.js",
+        "input": "can-observable-array/import-output.html",
+        "outputPath": "can-observable-array/import-output.html",
         "type": "fixture",
         "version": "6"
       },
@@ -1468,6 +1468,18 @@
       {
         "input": "can-stache-element/import-output.js",
         "outputPath": "can-stache-element/import-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-stache-element/import-input.html",
+        "outputPath": "can-stache-element/import-input.html",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-stache-element/import-output.html",
+        "outputPath": "can-stache-element/import-output.html",
         "type": "fixture",
         "version": "6"
       },

--- a/src/templates/can-observable-array/import-input.html
+++ b/src/templates/can-observable-array/import-input.html
@@ -1,0 +1,7 @@
+<script>
+  import DefineList from 'can-define/list/list';
+</script>
+
+<script>
+  const DefineList = require('can-define/list/list');
+</script>

--- a/src/templates/can-observable-array/import-input.js
+++ b/src/templates/can-observable-array/import-input.js
@@ -1,1 +1,0 @@
-import DefineList from 'can-define/list/list';

--- a/src/templates/can-observable-array/import-output.html
+++ b/src/templates/can-observable-array/import-output.html
@@ -1,0 +1,7 @@
+<script>
+  import ObservableArray from 'can-observable-array';
+</script>
+
+<script>
+  const ObservableArray = require('can-observable-array');
+</script>

--- a/src/templates/can-observable-array/import-output.js
+++ b/src/templates/can-observable-array/import-output.js
@@ -1,1 +1,0 @@
-import ObservableArray from 'can-observable-array';

--- a/src/templates/can-observable-array/import-test.js
+++ b/src/templates/can-observable-array/import-test.js
@@ -10,8 +10,8 @@ describe('can-observable-array', function() {
 
   it('Renames can-define/list import to can-observable-array', function() {
     const fn = require(toTest.file);
-    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.js')}`;
-    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.js')}`;
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.html')}`;
     utils.diffFiles(fn, inputPath, outputPath);
   });
 

--- a/src/templates/can-observable-array/import.js
+++ b/src/templates/can-observable-array/import.js
@@ -1,6 +1,7 @@
 // This is a generated file, see src/templates/can-extend/can-extend.js
 import getConfig from '../../../utils/getConfig';
 import renameImport, { updateImport } from '../../../utils/renameImport';
+import renameRequire from '../../../utils/renameRequire';
 import makeDebug from 'debug';
 import fileTransform from '../../../utils/fileUtil';
 
@@ -26,6 +27,13 @@ function transformer(file, api, options) {
     updateImport(j, root, {
       oldValue: 'DefineList',
       newValue: newLocalName
+    });
+    // Update require
+    // const DefineList = require('can-define/list')
+    renameRequire(root, {
+      oldSourceValues: ['can-define/list/list', 'can-define/list/'],
+      newSourceValue: 'can-observable-array',
+      newLocalName
     });
 
     debug(`Replacing import with ${newLocalName}`);

--- a/src/templates/can-observable-object/import-input.md
+++ b/src/templates/can-observable-object/import-input.md
@@ -13,3 +13,7 @@ import { Component, DefineMap } from 'can';
 ```js
 import { DefineMap } from 'can';
 ```
+
+```js
+const DefineMap = require('can-define/map/');
+```

--- a/src/templates/can-observable-object/import-output.md
+++ b/src/templates/can-observable-object/import-output.md
@@ -13,3 +13,7 @@ import { Component, ObservableObject } from 'can';
 ```js
 import { ObservableObject } from 'can';
 ```
+
+```js
+const ObservableObject = require('can-observable-object');
+```

--- a/src/templates/can-observable-object/import.js
+++ b/src/templates/can-observable-object/import.js
@@ -1,6 +1,7 @@
 // This is a generated file, see src/templates/can-extend/can-extend.js
 import getConfig from '../../../utils/getConfig';
 import renameImport, { updateImport } from '../../../utils/renameImport';
+import renameRequire from '../../../utils/renameRequire';
 import makeDebug from 'debug';
 import fileTransform from '../../../utils/fileUtil';
 
@@ -26,6 +27,13 @@ function transformer(file, api, options) {
     updateImport(j, root, {
       oldValue: 'DefineMap',
       newValue: newLocalName
+    });
+    // Update require
+    // const DefineMap = require('can-define/map')
+    renameRequire(root, {
+      oldSourceValues: ['can-define/map/map', 'can-define/map/'],
+      newSourceValue: 'can-observable-object',
+      newLocalName
     });
 
     debug(`Replacing import with ${newLocalName}`);

--- a/src/templates/can-property-definitions/observable-default-propertydefaults.js
+++ b/src/templates/can-property-definitions/observable-default-propertydefaults.js
@@ -41,6 +41,14 @@ function transformer(file, api, options) {
         }
       })
       .forEach(path => checkAndAddPropertyDefaults({ j, debug, path, root, propertyDefaultDeepObservable, defaultName: 'propertyDefaults' }));
+      // Use ClassExpression when the class is exported ie: module.exports = class MyApp extends StacheElement {}
+      root
+      .find(j.ClassExpression, {
+        superClass: {
+          name: extendedStacheClassName
+        }
+      })
+      .forEach(path => checkAndAddPropertyDefaults({ j, debug, path, root, propertyDefaultDeepObservable, defaultName: 'propertyDefaults' }));
 
       return root.toSource();
     });

--- a/src/templates/can-stache-element/import-input.html
+++ b/src/templates/can-stache-element/import-input.html
@@ -1,0 +1,3 @@
+<script>
+  const Component = require('can-component');
+</script>

--- a/src/templates/can-stache-element/import-output.html
+++ b/src/templates/can-stache-element/import-output.html
@@ -1,0 +1,3 @@
+<script>
+  const StacheElement = require('can-stache-element');
+</script>

--- a/src/templates/can-stache-element/import-test.js
+++ b/src/templates/can-stache-element/import-test.js
@@ -22,4 +22,11 @@ describe('can-stache-element/import', function() {
     utils.diffFiles(fn, inputPath, outputPath);
   });
 
+  it('Renames can-component import to can-stache-element .html', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
 });

--- a/src/templates/can-stache-element/import.js
+++ b/src/templates/can-stache-element/import.js
@@ -1,6 +1,7 @@
 // This is a generated file, see src/templates/can-extend/can-extend.js
 import getConfig from '../../../utils/getConfig';
 import renameImport, { updateImport } from '../../../utils/renameImport';
+import renameRequire from '../../../utils/renameRequire';
 import makeDebug from 'debug';
 import fileTransform from '../../../utils/fileUtil';
 
@@ -26,6 +27,13 @@ function transformer(file, api, options) {
     updateImport(j, root, {
       oldValue: 'Component',
       newValue: newLocalName
+    });
+    // Update require
+    // const Component = require('can-component')
+    renameRequire(root, {
+      oldSourceValues: ['can-component'],
+      newSourceValue: 'can-stache-element',
+      newLocalName
     });
 
     debug(`Replacing import with ${newLocalName}`);

--- a/src/templates/can-stache-element/input.html
+++ b/src/templates/can-stache-element/input.html
@@ -9,6 +9,16 @@
 </script>
 
 <script>
+  module.exports = Component.extend({
+    tag: "my-app",
+    view: `CanJS {{feels}} modules`,
+    ViewModel: {
+      feels: { default: "😍" }
+    }
+  });
+</script>
+
+<script>
   Component.extend({
     tag: "my-widget",
     view: `CanJS {{feels}} modules`,
@@ -17,7 +27,7 @@
         type: 'string',
         default: '😍'
       },
-      
+
       get feels () {
         return this.theFeeling
       },

--- a/src/templates/can-stache-element/output.html
+++ b/src/templates/can-stache-element/output.html
@@ -14,6 +14,21 @@
 </script>
 
 <script>
+  module.exports = class MyApp extends StacheElement {
+    static get view() {
+      return `CanJS {{feels}} modules`;
+    }
+
+    static get props() {
+      return {
+        feels: { default: "😍" }
+      };
+    }
+  };
+  customElements.define('my-app', MyApp);
+</script>
+
+<script>
   class MyWidget extends StacheElement {
     static get view() {
       return `CanJS {{feels}} modules`;
@@ -25,7 +40,7 @@
           type: 'string',
           default: '😍'
         },
-        
+
         get feels () {
           return this.theFeeling
         },

--- a/test/fixtures/version-6/can-observable-array/import-input.html
+++ b/test/fixtures/version-6/can-observable-array/import-input.html
@@ -1,0 +1,7 @@
+<script>
+  import DefineList from 'can-define/list/list';
+</script>
+
+<script>
+  const DefineList = require('can-define/list/list');
+</script>

--- a/test/fixtures/version-6/can-observable-array/import-input.js
+++ b/test/fixtures/version-6/can-observable-array/import-input.js
@@ -1,1 +1,0 @@
-import DefineList from 'can-define/list/list';

--- a/test/fixtures/version-6/can-observable-array/import-output.html
+++ b/test/fixtures/version-6/can-observable-array/import-output.html
@@ -1,0 +1,7 @@
+<script>
+  import ObservableArray from 'can-observable-array';
+</script>
+
+<script>
+  const ObservableArray = require('can-observable-array');
+</script>

--- a/test/fixtures/version-6/can-observable-array/import-output.js
+++ b/test/fixtures/version-6/can-observable-array/import-output.js
@@ -1,1 +1,0 @@
-import ObservableArray from 'can-observable-array';

--- a/test/fixtures/version-6/can-observable-object/import-input.md
+++ b/test/fixtures/version-6/can-observable-object/import-input.md
@@ -13,3 +13,7 @@ import { Component, DefineMap } from 'can';
 ```js
 import { DefineMap } from 'can';
 ```
+
+```js
+const DefineMap = require('can-define/map/');
+```

--- a/test/fixtures/version-6/can-observable-object/import-output.md
+++ b/test/fixtures/version-6/can-observable-object/import-output.md
@@ -13,3 +13,7 @@ import { Component, ObservableObject } from 'can';
 ```js
 import { ObservableObject } from 'can';
 ```
+
+```js
+const ObservableObject = require('can-observable-object');
+```

--- a/test/fixtures/version-6/can-stache-element/can-stache-element-input.html
+++ b/test/fixtures/version-6/can-stache-element/can-stache-element-input.html
@@ -9,6 +9,16 @@
 </script>
 
 <script>
+  module.exports = Component.extend({
+    tag: "my-app",
+    view: `CanJS {{feels}} modules`,
+    ViewModel: {
+      feels: { default: "😍" }
+    }
+  });
+</script>
+
+<script>
   Component.extend({
     tag: "my-widget",
     view: `CanJS {{feels}} modules`,
@@ -17,7 +27,7 @@
         type: 'string',
         default: '😍'
       },
-      
+
       get feels () {
         return this.theFeeling
       },

--- a/test/fixtures/version-6/can-stache-element/can-stache-element-output.html
+++ b/test/fixtures/version-6/can-stache-element/can-stache-element-output.html
@@ -14,6 +14,21 @@
 </script>
 
 <script>
+  module.exports = class MyApp extends StacheElement {
+    static get view() {
+      return `CanJS {{feels}} modules`;
+    }
+
+    static get props() {
+      return {
+        feels: { default: "😍" }
+      };
+    }
+  };
+  customElements.define('my-app', MyApp);
+</script>
+
+<script>
   class MyWidget extends StacheElement {
     static get view() {
       return `CanJS {{feels}} modules`;
@@ -25,7 +40,7 @@
           type: 'string',
           default: '😍'
         },
-        
+
         get feels () {
           return this.theFeeling
         },

--- a/test/fixtures/version-6/can-stache-element/import-input.html
+++ b/test/fixtures/version-6/can-stache-element/import-input.html
@@ -1,0 +1,3 @@
+<script>
+  const Component = require('can-component');
+</script>

--- a/test/fixtures/version-6/can-stache-element/import-output.html
+++ b/test/fixtures/version-6/can-stache-element/import-output.html
@@ -1,0 +1,3 @@
+<script>
+  const StacheElement = require('can-stache-element');
+</script>


### PR DESCRIPTION
There was an issue with a Component being exported it was looking for a varDeclaration so that it could add the customElements.define for the StacheElement. Updated an issue with the exported StacheElement for adding the propertyDefaults.

Closes https://github.com/canjs/can-migrate/issues/134