### PR TITLE
Seal StacheElements and ObservableObjects

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -1809,5 +1809,46 @@
         "version": "6"
       }
     ]
+  },
+  {
+    "copy": [
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed.js",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed.js",
+        "type": "transform",
+        "version": "6",
+        "order": 60
+      },
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed-input.js",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed-input.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed-output.js",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed-input.html",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed-input.html",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed-output.html",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed-output.html",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-property-definitions/observable-object-stache-element-sealed-test.js",
+        "outputPath": "can-property-definitions/observable-object-stache-element-sealed-test.js",
+        "type": "test",
+        "version": "6"
+      }
+    ]
   }
 ]

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed-input.html
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed-input.html
@@ -1,0 +1,22 @@
+<script>
+  import { ObservableObject } from "can";
+  import DeepObservable from "can-deep-observable";
+
+  class Foo extends ObservableObject {
+    static get propertyDefaults() {
+      return DeepObservable;
+    }
+  };
+</script>
+
+<script>
+  import { StacheElement } from "can";
+
+  class TheTag extends StacheElement {
+    static get view() {
+      return `
+        {{this.foo}}
+      `;
+    }
+  };
+</script>

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed-input.js
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed-input.js
@@ -1,0 +1,8 @@
+import { ObservableObject } from "can";
+import DeepObservable from "can-deep-observable";
+
+class Foo extends ObservableObject {
+  static get propertyDefaults() {
+    return DeepObservable;
+  }
+};

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed-output.html
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed-output.html
@@ -1,0 +1,30 @@
+<script>
+  import { ObservableObject } from "can";
+  import DeepObservable from "can-deep-observable";
+
+  class Foo extends ObservableObject {
+    static get propertyDefaults() {
+      return DeepObservable;
+    }
+
+    static get seal() {
+      return true;
+    }
+  };
+</script>
+
+<script>
+  import { StacheElement } from "can";
+
+  class TheTag extends StacheElement {
+    static get view() {
+      return `
+        {{this.foo}}
+      `;
+    }
+
+    static get seal() {
+      return true;
+    }
+  };
+</script>

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed-output.js
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed-output.js
@@ -1,0 +1,12 @@
+import { ObservableObject } from "can";
+import DeepObservable from "can-deep-observable";
+
+class Foo extends ObservableObject {
+  static get propertyDefaults() {
+    return DeepObservable;
+  }
+
+  static get seal() {
+    return true;
+  }
+};

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed-test.js
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed-test.js
@@ -1,0 +1,23 @@
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'can-property-definitions/observable-object-stache-element-sealed.js';
+})[0];
+
+
+describe('Seal ObservableObject and StacheElement ', function() {
+  it('sets seal property to true if not already set', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+  it('runs in .html files', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.html')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.html')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+});

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed.js
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed.js
@@ -1,6 +1,7 @@
 import makeDebug from 'debug';
 import getConfig from '../../../utils/getConfig';
 import fileTransform from '../../../utils/fileUtil';
+import { createMethod } from '../../../utils/classUtils';
 
 function transformer(file, api, options) {
   const debug = makeDebug(`can-migrate:can-property-definitions/sealed:${file.path}`);
@@ -13,20 +14,20 @@ function transformer(file, api, options) {
   return fileTransform(file, function (source) {
     const root = j(source);
     root
-    .find(j.ClassDeclaration, {
-     superClass: {
-          name: extendedObjectClassName
-        }
-    })
-    .forEach(path => addSeal({j, debug, path}));
+      .find(j.ClassDeclaration, {
+      superClass: {
+            name: extendedObjectClassName
+          }
+      })
+      .forEach(path => addSeal({j, debug, path}));
 
     root
-    .find(j.ClassDeclaration, {
-     superClass: {
-          name: extendedStacheClassName
-        }
-    })
-    .forEach(path => addSeal({j, debug, path}));
+      .find(j.ClassDeclaration, {
+      superClass: {
+            name: extendedStacheClassName
+          }
+      })
+      .forEach(path => addSeal({j, debug, path}));
 
     return root.toSource();
   });
@@ -43,15 +44,13 @@ function addSeal({j, debug, path}) {
 
   if (!sealed.length) {
     debug(`Setting seal property`);
-    path.value.body.body.push(
-      j.methodDefinition('get', j.identifier('seal'), j.functionExpression(
-        null,
-        [],
-        j.blockStatement([
-           j.returnStatement(j.identifier('true'))
-        ])
-      ),true)
-    );
+    path.value.body.body.push(createMethod({
+      j,
+      name: 'seal',
+      blockStatement:  j.blockStatement([j.returnStatement(j.identifier('true'))]),
+      isStatic: true,
+      method: false
+    }));
   }
 }
 

--- a/src/templates/can-property-definitions/observable-object-stache-element-sealed.js
+++ b/src/templates/can-property-definitions/observable-object-stache-element-sealed.js
@@ -1,0 +1,60 @@
+import makeDebug from 'debug';
+import getConfig from '../../../utils/getConfig';
+import fileTransform from '../../../utils/fileUtil';
+
+function transformer(file, api, options) {
+  const debug = makeDebug(`can-migrate:can-property-definitions/sealed:${file.path}`);
+  const j = api.jscodeshift;
+  const config = getConfig(options.config);
+  const extendedObjectClassName = config.moduleToName['can-observable-object'];
+  const extendedStacheClassName = config.moduleToName['can-stache-element'];
+
+  // Transform different file types
+  return fileTransform(file, function (source) {
+    const root = j(source);
+    root
+    .find(j.ClassDeclaration, {
+     superClass: {
+          name: extendedObjectClassName
+        }
+    })
+    .forEach(path => addSeal({j, debug, path}));
+
+    root
+    .find(j.ClassDeclaration, {
+     superClass: {
+          name: extendedStacheClassName
+        }
+    })
+    .forEach(path => addSeal({j, debug, path}));
+
+    return root.toSource();
+  });
+}
+
+function addSeal({j, debug, path}) {
+  const sealed = j(path).find(j.MethodDefinition, {
+    key: {
+      name: 'seal'
+    },
+    kind: 'get',
+    static: true
+  });
+
+  if (!sealed.length) {
+    debug(`Setting seal property`);
+    path.value.body.body.push(
+      j.methodDefinition('get', j.identifier('seal'), j.functionExpression(
+        null,
+        [],
+        j.blockStatement([
+           j.returnStatement(j.identifier('true'))
+        ])
+      ),true)
+    );
+  }
+}
+
+transformer.forceJavaScriptTransform = true;
+
+export default transformer;

--- a/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-input.html
+++ b/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-input.html
@@ -1,0 +1,22 @@
+<script>
+  import { ObservableObject } from "can";
+  import DeepObservable from "can-deep-observable";
+
+  class Foo extends ObservableObject {
+    static get propertyDefaults() {
+      return DeepObservable;
+    }
+  };
+</script>
+
+<script>
+  import { StacheElement } from "can";
+
+  class TheTag extends StacheElement {
+    static get view() {
+      return `
+        {{this.foo}}
+      `;
+    }
+  };
+</script>

--- a/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-input.js
+++ b/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-input.js
@@ -1,0 +1,8 @@
+import { ObservableObject } from "can";
+import DeepObservable from "can-deep-observable";
+
+class Foo extends ObservableObject {
+  static get propertyDefaults() {
+    return DeepObservable;
+  }
+};

--- a/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-output.html
+++ b/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-output.html
@@ -1,0 +1,30 @@
+<script>
+  import { ObservableObject } from "can";
+  import DeepObservable from "can-deep-observable";
+
+  class Foo extends ObservableObject {
+    static get propertyDefaults() {
+      return DeepObservable;
+    }
+
+    static get seal() {
+      return true;
+    }
+  };
+</script>
+
+<script>
+  import { StacheElement } from "can";
+
+  class TheTag extends StacheElement {
+    static get view() {
+      return `
+        {{this.foo}}
+      `;
+    }
+
+    static get seal() {
+      return true;
+    }
+  };
+</script>

--- a/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-output.js
+++ b/test/fixtures/version-6/can-property-definitions/observable-object-stache-element-sealed-output.js
@@ -1,0 +1,12 @@
+import { ObservableObject } from "can";
+import DeepObservable from "can-deep-observable";
+
+class Foo extends ObservableObject {
+  static get propertyDefaults() {
+    return DeepObservable;
+  }
+
+  static get seal() {
+    return true;
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -123,3 +123,4 @@ require('../lib/transforms/version-6/can-property-definitions/connectedcallback-
 require('../lib/transforms/version-6/can-observable-array/array-constructor-test.js');
 require('../lib/transforms/version-6/can-observable-object/constructor-test.js');
 require('../lib/transforms/version-6/can-property-definitions/observable-default-propertydefaults-test.js');
+require('../lib/transforms/version-6/can-property-definitions/observable-object-stache-element-sealed-test.js');


### PR DESCRIPTION
Fixes #135 

For `ObservableObject` and `StacheElement`, transforms:
```js
class Foo extends ObservableObject {
   //props and methods here
};

class TheTag extends StacheElement {
    static get view() {
      return `
        {{this.foo}}
      `;
    }
  };
```
to 
```js
class Foo extends ObservableObject {
  //props and methods here

  static get seal() {
    return true;
  }
};

class TheTag extends StacheElement {
    static get view() {
      return `
        {{this.foo}}
      `;
    }

    static get seal() {
      return true;
    }
  };
```

