### PR TITLE
Fix sub-nodes error when reading the getter

### DIFF
--- a/src/templates/can-property-definitions/property-definitions-input.js
+++ b/src/templates/can-property-definitions/property-definitions-input.js
@@ -10,7 +10,14 @@ class Foo extends ObservableArray {
         type: 'boolean',
         default: false
       },
-      items: 'any'
+      items: 'any',
+      parentFoo: {
+        set(parentFoo){
+            this.forEach(function(sub){});
+            return parentFoo;
+        },
+        serialize: false
+      }
     };
   }
 

--- a/src/templates/can-property-definitions/property-definitions-output.js
+++ b/src/templates/can-property-definitions/property-definitions-output.js
@@ -10,7 +10,14 @@ class Foo extends ObservableArray {
         type: type.maybeConvert(Boolean),
         default: false
       },
-      items: 'any'
+      items: 'any',
+      parentFoo: {
+        set(parentFoo){
+            this.forEach(function(sub){});
+            return parentFoo;
+        },
+        enumerable: false
+      }
     };
   }
 

--- a/src/templates/can-property-definitions/property-definitions.js
+++ b/src/templates/can-property-definitions/property-definitions.js
@@ -72,7 +72,7 @@ function transformer(file, api) {
          */
         replaceDefaultFunction(j, 'FunctionExpression', j(prop));
         replaceDefaultFunction(j, 'ArrowFunctionExpression', j(prop));
-        // Convert `Default: Todo` into 
+        // Convert `Default: Todo` into
         // Default: {
         //   get default () {
         //     return new Todo()
@@ -91,7 +91,9 @@ function transformer(file, api) {
       j(prop).find(j.FunctionExpression)
         .forEach(prop => {
           // Check for the get methods
-          if (prop.parentPath.value.key.name === 'get') {
+          // The type must be property to avoid
+          // BlockStatement error see #139
+          if (prop.parentPath.value.type === 'Property' && prop.parentPath.value.key.name === 'get') {
             // We only want getters with 2 params
             if (prop.value.params.length === 2) {
               // Change the name

--- a/test/fixtures/version-6/can-property-definitions/property-definitions-input.js
+++ b/test/fixtures/version-6/can-property-definitions/property-definitions-input.js
@@ -10,7 +10,14 @@ class Foo extends ObservableArray {
         type: 'boolean',
         default: false
       },
-      items: 'any'
+      items: 'any',
+      parentFoo: {
+        set(parentFoo){
+            this.forEach(function(sub){});
+            return parentFoo;
+        },
+        serialize: false
+      }
     };
   }
 

--- a/test/fixtures/version-6/can-property-definitions/property-definitions-output.js
+++ b/test/fixtures/version-6/can-property-definitions/property-definitions-output.js
@@ -10,7 +10,14 @@ class Foo extends ObservableArray {
         type: type.maybeConvert(Boolean),
         default: false
       },
-      items: 'any'
+      items: 'any',
+      parentFoo: {
+        set(parentFoo){
+            this.forEach(function(sub){});
+            return parentFoo;
+        },
+        enumerable: false
+      }
     };
   }
 


### PR DESCRIPTION
fixes #139 

Some types are not transformed because of an error when convert async getters into async's.
The error happens when there's a function like a setter, the codemod tries to convert the sub-nodes of the function in the AST.

Fix a transformation like this (see `set(parentFoo)`):
```js
class SubtaskList extends ObservableArray {
    static get props() {
        return {
            "#": {
                Type: Subtask
            },
            parentTodo: {
                set(parentTodo){
                    this.forEach(function(subtask){
                    });
                    return parentTodo;
                },
                serialize: false
            }
        };
    }
};
```

to
```js
class SubtaskList extends ObservableArray {
    static get props() {
        return {
            parentTodo: {
                set(parentTodo){
                    this.forEach(function(subtask){
                    });
                    return parentTodo;
                },
                enumerable: false
            }
        };
    }

    static get items() {
        return {
            type: type.maybeConvert(Subtask)
        };
    }
}
```
