### PR TITLE
Comments should not be removed

### DIFF
--- a/src/templates/can-observable-array/observable-array-input.html
+++ b/src/templates/can-observable-array/observable-array-input.html
@@ -1,4 +1,8 @@
 <script>
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 const MyOtherList = DefineList.extend({
   '#': 'string',
 
@@ -9,6 +13,7 @@ const MyOtherList = DefineList.extend({
 </script>
 
 <script>
+// Foo bar
 Messages.List = DefineList.extend({
   '#': 'string',
 

--- a/src/templates/can-observable-array/observable-array-input.js
+++ b/src/templates/can-observable-array/observable-array-input.js
@@ -1,5 +1,10 @@
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 const MyList = DefineList.extend({ '#': 'string' });
 
+// A comment
 const MyOtherList = DefineList.extend({
   '#': 'string',
 

--- a/src/templates/can-observable-array/observable-array-output.html
+++ b/src/templates/can-observable-array/observable-array-output.html
@@ -1,4 +1,8 @@
 <script>
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 class MyOtherList extends ObservableArray {
   static get props() {
     return {
@@ -13,6 +17,7 @@ class MyOtherList extends ObservableArray {
 </script>
 
 <script>
+// Foo bar
 class MessagesList extends ObservableArray {
   static get props() {
     return {

--- a/src/templates/can-observable-array/observable-array-output.js
+++ b/src/templates/can-observable-array/observable-array-output.js
@@ -1,9 +1,14 @@
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 class MyList extends ObservableArray {
   static get props() {
     return { '#': 'string' };
   }
 }
 
+// A comment
 class MyOtherList extends ObservableArray {
   static get props() {
     return {

--- a/src/templates/can-observable-object/observable-object-input.js
+++ b/src/templates/can-observable-object/observable-object-input.js
@@ -1,3 +1,4 @@
+// Comment line should not be removed
 const Foo = DefineMap.extend({
   name: 'string',
   completed: {
@@ -6,6 +7,11 @@ const Foo = DefineMap.extend({
   }
 });
 
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 const VM = DefineMap.extend({
   firstName: 'string',
   lastName: 'string',

--- a/src/templates/can-observable-object/observable-object-input.md
+++ b/src/templates/can-observable-object/observable-object-input.md
@@ -1,4 +1,5 @@
 ```js
+// Comment line should not be removed
 const Foo = DefineMap.extend({
   name: 'string',
   completed: {
@@ -9,6 +10,11 @@ const Foo = DefineMap.extend({
 ```
 
 ```js
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 const VM = DefineMap.extend({
   firstName: 'string',
   lastName: 'string',

--- a/src/templates/can-observable-object/observable-object-output.js
+++ b/src/templates/can-observable-object/observable-object-output.js
@@ -1,3 +1,4 @@
+// Comment line should not be removed
 class Foo extends ObservableObject {
   static get props() {
     return {
@@ -10,6 +11,11 @@ class Foo extends ObservableObject {
   }
 }
 
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 class VM extends ObservableObject {
   static get props() {
     return {

--- a/src/templates/can-observable-object/observable-object-output.md
+++ b/src/templates/can-observable-object/observable-object-output.md
@@ -1,4 +1,5 @@
 ```js
+// Comment line should not be removed
 class Foo extends ObservableObject {
   static get props() {
     return {
@@ -13,6 +14,11 @@ class Foo extends ObservableObject {
 ```
 
 ```js
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 class VM extends ObservableObject {
   static get props() {
     return {

--- a/src/templates/can-property-definitions/property-functions-input.js
+++ b/src/templates/can-property-definitions/property-functions-input.js
@@ -6,6 +6,7 @@ class Bar extends ObservableObject {
         return new Item(args);
       },
       get sayHi () {
+        // Comment inside getter
         return `Hello ${this.name}`;
       },
       set sayHi (val) {

--- a/src/templates/can-property-definitions/property-functions-input.js
+++ b/src/templates/can-property-definitions/property-functions-input.js
@@ -18,6 +18,7 @@ class Bar extends ObservableObject {
 class Foo extends ObservableObject {
   static get props() {
     return {
+      // The comment should not be removed
       async createItem(args) {
         return new Item(args);
       }

--- a/src/templates/can-property-definitions/property-functions-output.js
+++ b/src/templates/can-property-definitions/property-functions-output.js
@@ -4,6 +4,7 @@ class Bar extends ObservableObject {
       name: 'string',
 
       get sayHi () {
+        // Comment inside getter
         return `Hello ${this.name}`;
       },
 

--- a/src/templates/can-property-definitions/property-functions-output.js
+++ b/src/templates/can-property-definitions/property-functions-output.js
@@ -23,6 +23,7 @@ class Foo extends ObservableObject {
     return {};
   }
 
+  // The comment should not be removed
   async createItem(args) {
     return new Item(args);
   }

--- a/src/templates/can-property-definitions/property-functions.js
+++ b/src/templates/can-property-definitions/property-functions.js
@@ -5,21 +5,36 @@ import fileTransform from '../../../utils/fileUtil';
 function transformer(file, api) {
   const debug = makeDebug(`can-migrate:can-property-definitions/property-functions:${file.path}`);
   const j = api.jscodeshift;
-  
+
   return fileTransform(file, function (source) {
     const root = j(source);
-    
+
     return find(root, 'FunctionExpression', function (props, rootPath) {
       const rootDefine = rootPath.value.value.body.body[0].argument.properties;
 
       return props.forEach(prop => {
         if (prop.kind !== 'get' && prop.kind !== 'set') {
+
           // Add the method to the class body
-          rootPath.parent.value.body.push(j.methodDefinition(
+          const method = j.methodDefinition(
             'method',
             prop.key,
             prop.value
-          ));
+          );
+
+          // Keep the comments where they belong
+          if (prop.leadingComments && prop.leadingComments.length) {
+            method.comments = method.comments ? method.comments : [];
+            prop.leadingComments.forEach(function(comment){
+              if (comment.type === 'CommentLine') {
+                method.comments.push(j.commentLine(comment.value, true, false));
+              }
+              if (comment.type === 'CommentBlock') {
+                method.comments.push(j.commentBlock(comment.value, true, false));
+              }
+            });
+          }
+          rootPath.parent.value.body.push(method);
 
           debug(`Removing ${prop.key} from define () {} into class definition`);
 

--- a/test/fixtures/version-6/can-observable-array/observable-array-input.html
+++ b/test/fixtures/version-6/can-observable-array/observable-array-input.html
@@ -1,4 +1,8 @@
 <script>
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 const MyOtherList = DefineList.extend({
   '#': 'string',
 
@@ -9,6 +13,7 @@ const MyOtherList = DefineList.extend({
 </script>
 
 <script>
+// Foo bar
 Messages.List = DefineList.extend({
   '#': 'string',
 

--- a/test/fixtures/version-6/can-observable-array/observable-array-input.js
+++ b/test/fixtures/version-6/can-observable-array/observable-array-input.js
@@ -1,5 +1,10 @@
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 const MyList = DefineList.extend({ '#': 'string' });
 
+// A comment
 const MyOtherList = DefineList.extend({
   '#': 'string',
 

--- a/test/fixtures/version-6/can-observable-array/observable-array-output.html
+++ b/test/fixtures/version-6/can-observable-array/observable-array-output.html
@@ -1,4 +1,8 @@
 <script>
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 class MyOtherList extends ObservableArray {
   static get props() {
     return {
@@ -13,6 +17,7 @@ class MyOtherList extends ObservableArray {
 </script>
 
 <script>
+// Foo bar
 class MessagesList extends ObservableArray {
   static get props() {
     return {

--- a/test/fixtures/version-6/can-observable-array/observable-array-output.js
+++ b/test/fixtures/version-6/can-observable-array/observable-array-output.js
@@ -1,9 +1,14 @@
+/**
+ * Multiline comment
+ * Foo Bar
+ */
 class MyList extends ObservableArray {
   static get props() {
     return { '#': 'string' };
   }
 }
 
+// A comment
 class MyOtherList extends ObservableArray {
   static get props() {
     return {

--- a/test/fixtures/version-6/can-observable-object/observable-object-input.js
+++ b/test/fixtures/version-6/can-observable-object/observable-object-input.js
@@ -1,3 +1,4 @@
+// Comment line should not be removed
 const Foo = DefineMap.extend({
   name: 'string',
   completed: {
@@ -6,6 +7,11 @@ const Foo = DefineMap.extend({
   }
 });
 
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 const VM = DefineMap.extend({
   firstName: 'string',
   lastName: 'string',

--- a/test/fixtures/version-6/can-observable-object/observable-object-input.md
+++ b/test/fixtures/version-6/can-observable-object/observable-object-input.md
@@ -1,4 +1,5 @@
 ```js
+// Comment line should not be removed
 const Foo = DefineMap.extend({
   name: 'string',
   completed: {
@@ -9,6 +10,11 @@ const Foo = DefineMap.extend({
 ```
 
 ```js
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 const VM = DefineMap.extend({
   firstName: 'string',
   lastName: 'string',

--- a/test/fixtures/version-6/can-observable-object/observable-object-output.js
+++ b/test/fixtures/version-6/can-observable-object/observable-object-output.js
@@ -1,3 +1,4 @@
+// Comment line should not be removed
 class Foo extends ObservableObject {
   static get props() {
     return {
@@ -10,6 +11,11 @@ class Foo extends ObservableObject {
   }
 }
 
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 class VM extends ObservableObject {
   static get props() {
     return {

--- a/test/fixtures/version-6/can-observable-object/observable-object-output.md
+++ b/test/fixtures/version-6/can-observable-object/observable-object-output.md
@@ -1,4 +1,5 @@
 ```js
+// Comment line should not be removed
 class Foo extends ObservableObject {
   static get props() {
     return {
@@ -13,6 +14,11 @@ class Foo extends ObservableObject {
 ```
 
 ```js
+/**
+ * Comment Block should not be removed
+ * Foo bar
+ */
+//foo
 class VM extends ObservableObject {
   static get props() {
     return {

--- a/test/fixtures/version-6/can-property-definitions/property-functions-input.js
+++ b/test/fixtures/version-6/can-property-definitions/property-functions-input.js
@@ -6,6 +6,7 @@ class Bar extends ObservableObject {
         return new Item(args);
       },
       get sayHi () {
+        // Comment inside getter
         return `Hello ${this.name}`;
       },
       set sayHi (val) {

--- a/test/fixtures/version-6/can-property-definitions/property-functions-input.js
+++ b/test/fixtures/version-6/can-property-definitions/property-functions-input.js
@@ -18,6 +18,7 @@ class Bar extends ObservableObject {
 class Foo extends ObservableObject {
   static get props() {
     return {
+      // The comment should not be removed
       async createItem(args) {
         return new Item(args);
       }

--- a/test/fixtures/version-6/can-property-definitions/property-functions-output.js
+++ b/test/fixtures/version-6/can-property-definitions/property-functions-output.js
@@ -4,6 +4,7 @@ class Bar extends ObservableObject {
       name: 'string',
 
       get sayHi () {
+        // Comment inside getter
         return `Hello ${this.name}`;
       },
 

--- a/test/fixtures/version-6/can-property-definitions/property-functions-output.js
+++ b/test/fixtures/version-6/can-property-definitions/property-functions-output.js
@@ -23,6 +23,7 @@ class Foo extends ObservableObject {
     return {};
   }
 
+  // The comment should not be removed
   async createItem(args) {
     return new Item(args);
   }


### PR DESCRIPTION
Fix #138 

This keeps comments with their methods and classes:
Transforms:

```js
// Model subtask
const Subtask = DefineMap.extend("Subtask",{
    // parentTodo should not be serialized
    parentTodo: {serialize: false, type: "any"},
    // a save utility that actually saves the parent todo
    save(){
        this.parentTodo.save();
    }
});
```

to:

```js
// Model subtask
class Subtask extends ObservableObject {
    static get props() {
        return {
            // parentTodo should not be serialized
            parentTodo: {enumerable: false, type: type.Any}
        };
    }

    // a save utility that actually saves the parent todo
    save() {
        this.parentTodo.save();
    }

    static get propertyDefaults() {
        return DeepObservable;
    }
};
```

