### PR TITLE
Fix import does too much

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -1500,6 +1500,18 @@
         "outputPath": "can-stache-element/import-test.js",
         "type": "test",
         "version": "6"
+      },
+      {
+        "input": "can-stache-element/import-input-deconstructed-w-other.js",
+        "outputPath": "can-stache-element/import-input-deconstructed-w-other.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-stache-element/import-output-deconstructed-w-other.js",
+        "outputPath": "can-stache-element/import-output-deconstructed-w-other.js",
+        "type": "fixture",
+        "version": "6"
       }
     ]
   },

--- a/src/templates/can-stache-element/import-input-deconstructed-w-other.js
+++ b/src/templates/can-stache-element/import-input-deconstructed-w-other.js
@@ -1,0 +1,2 @@
+import { Component as YlemComponent } from "ylem";
+import { Component } from "can";

--- a/src/templates/can-stache-element/import-output-deconstructed-w-other.js
+++ b/src/templates/can-stache-element/import-output-deconstructed-w-other.js
@@ -1,0 +1,2 @@
+import { Component as YlemComponent } from "ylem";
+import { StacheElement } from "can";

--- a/src/templates/can-stache-element/import-test.js
+++ b/src/templates/can-stache-element/import-test.js
@@ -29,4 +29,11 @@ describe('can-stache-element/import', function() {
     utils.diffFiles(fn, inputPath, outputPath);
   });
 
+  it('Renames can-component import to can-stache-element deconstructed with other Component keywords', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input-deconstructed-w-other.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output-deconstructed-w-other.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
 });

--- a/src/utils/renameImport.js
+++ b/src/utils/renameImport.js
@@ -38,7 +38,8 @@ export function updateImport (j, root, { oldValue, newValue }) {
     .filter(p => {
       return  p.parent.node.type === 'Program' &&
               p.get('specifiers', 0, 'type').value !== 'ImportNamespaceSpecifier' &&
-              p.value.source.value === 'can' || p.value.source.value === '//unpkg.com/can@5/everything.mjs';
+              p.value.source.value === 'can' ||
+              /\/\/unpkg.com\/can@5?(\.[0-9]+)?(\.[0-9]+)?\/everything.mjs/.test(p.value.source.value);
     })
     .forEach(path => {
       path.value.specifiers.forEach((specifier, index) => {

--- a/src/utils/renameImport.js
+++ b/src/utils/renameImport.js
@@ -36,7 +36,9 @@ export function updateImport (j, root, { oldValue, newValue }) {
   root
     .find(j.ImportDeclaration)
     .filter(p => {
-      return p.parent.node.type === 'Program' && p.get('specifiers', 0, 'type').value !== 'ImportNamespaceSpecifier';
+      return  p.parent.node.type === 'Program' &&
+              p.get('specifiers', 0, 'type').value !== 'ImportNamespaceSpecifier' &&
+              p.value.source.value === 'can' || p.value.source.value === '//unpkg.com/can@5/everything.mjs';
     })
     .forEach(path => {
       path.value.specifiers.forEach((specifier, index) => {

--- a/src/utils/renameImport.js
+++ b/src/utils/renameImport.js
@@ -39,7 +39,7 @@ export function updateImport (j, root, { oldValue, newValue }) {
       return  p.parent.node.type === 'Program' &&
               p.get('specifiers', 0, 'type').value !== 'ImportNamespaceSpecifier' &&
               p.value.source.value === 'can' ||
-              /\/\/unpkg.com\/can@5?(\.[0-9]+)?(\.[0-9]+)?\/everything.mjs/.test(p.value.source.value);
+              /\/\/unpkg.com\/can@5(\.[0-9]+)?(\.[0-9]+)?\/[a-z]+.mjs/.test(p.value.source.value);
     })
     .forEach(path => {
       path.value.specifiers.forEach((specifier, index) => {

--- a/test/fixtures/version-6/can-stache-element/import-input-deconstructed-w-other.js
+++ b/test/fixtures/version-6/can-stache-element/import-input-deconstructed-w-other.js
@@ -1,0 +1,2 @@
+import { Component as YlemComponent } from "ylem";
+import { Component } from "can";

--- a/test/fixtures/version-6/can-stache-element/import-output-deconstructed-w-other.js
+++ b/test/fixtures/version-6/can-stache-element/import-output-deconstructed-w-other.js
@@ -1,0 +1,2 @@
+import { Component as YlemComponent } from "ylem";
+import { StacheElement } from "can";


### PR DESCRIPTION
Fixes https://github.com/canjs/can-migrate/issues/147

Fix conversion of :
```js
import { Component as YlemComponent } from "ylem";
import { Component } from "can";
```

to
```js
import { Component as YlemComponent } from "ylem";
import { StacheElement } from "can";
```
