### PR TITLE
Handle can-component conversion when imported with another name

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -678,6 +678,18 @@
         "version": "6"
       },
       {
+        "input": "can-stache-element/can-stache-element-other-name-input.js",
+        "outputPath": "can-stache-element/can-stache-element-other-name-input.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-stache-element/can-stache-element-other-name-output.js",
+        "outputPath": "can-stache-element/can-stache-element-other-name-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
         "input": "can-stache-element/can-stache-element-test.js",
         "outputPath": "can-stache-element/can-stache-element-test.js",
         "type": "test",

--- a/src/templates/can-stache-element/can-stache-element-other-name-input.js
+++ b/src/templates/can-stache-element/can-stache-element-other-name-input.js
@@ -1,0 +1,8 @@
+import React, { Component } from "react";
+import { Component as CanComponent } from "can";
+
+CanComponent.extend({
+  tag: "my-app",
+  view: "Hello World",
+  ViewModel: {}
+});

--- a/src/templates/can-stache-element/can-stache-element-other-name-output.js
+++ b/src/templates/can-stache-element/can-stache-element-other-name-output.js
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+import { Component as CanComponent } from "can";
+
+class MyApp extends StacheElement {
+  static get view() {
+    return "Hello World";
+  }
+
+  static get props() {
+    return {};
+  }
+};
+customElements.define('my-app', MyApp);

--- a/src/templates/can-stache-element/can-stache-element-test.js
+++ b/src/templates/can-stache-element/can-stache-element-test.js
@@ -29,4 +29,11 @@ describe('can-stache-element', function() {
     utils.diffFiles(fn, inputPath, outputPath);
   });
 
+  it('Converts Component.extend to class extends StacheElement when can-component imported with other name', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-other-name-input.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-other-name-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
 });

--- a/test/fixtures/version-6/can-stache-element/can-stache-element-other-name-input.js
+++ b/test/fixtures/version-6/can-stache-element/can-stache-element-other-name-input.js
@@ -1,0 +1,8 @@
+import React, { Component } from "react";
+import { Component as CanComponent } from "can";
+
+CanComponent.extend({
+  tag: "my-app",
+  view: "Hello World",
+  ViewModel: {}
+});

--- a/test/fixtures/version-6/can-stache-element/can-stache-element-other-name-output.js
+++ b/test/fixtures/version-6/can-stache-element/can-stache-element-other-name-output.js
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+import { Component as CanComponent } from "can";
+
+class MyApp extends StacheElement {
+  static get view() {
+    return "Hello World";
+  }
+
+  static get props() {
+    return {};
+  }
+};
+customElements.define('my-app', MyApp);


### PR DESCRIPTION
Handle the case when `can-component` is imported with another name:

From:
```js
import React, { Component } from "react";
import { Component as CanComponent } from "can";

CanComponent.extend({
  tag: "my-app",
  view: "Hello World",
  ViewModel: {}
});
```
to 
```js
import React, { Component } from "react";
import { Component as CanComponent } from "can";

class MyApp extends StacheElement {
  static get view() {
    return "Hello World";
  }

  static get props() {
    return {};
  }
};
customElements.define('my-app', MyApp);
```
closes #149