### PR TITLE
Fix inline DefineMap.extend as a property

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -715,6 +715,18 @@
         "version": "6"
       },
       {
+        "input": "can-observable-object/observable-object-inline-input.js",
+        "outputPath": "can-observable-object/observable-object-inline-input.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "can-observable-object/observable-object-inline-output.js",
+        "outputPath": "can-observable-object/observable-object-inline-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
         "input": "can-observable-object/observable-object-test.js",
         "outputPath": "can-observable-object/observable-object-test.js",
         "type": "test",

--- a/src/templates/can-observable-object/observable-object-inline-input.js
+++ b/src/templates/can-observable-object/observable-object-inline-input.js
@@ -1,0 +1,6 @@
+const TodosList = DefineList.extend({
+  "#": DefineMap.extend({
+      id: "number",
+      name: "string"
+  })
+});

--- a/src/templates/can-observable-object/observable-object-inline-output.js
+++ b/src/templates/can-observable-object/observable-object-inline-output.js
@@ -1,5 +1,5 @@
 const TodosList = DefineList.extend({
-  "#": class Model extends ObservableObject {
+  "#": class  extends ObservableObject {
     static get props() {
       return {
           id: "number",

--- a/src/templates/can-observable-object/observable-object-inline-output.js
+++ b/src/templates/can-observable-object/observable-object-inline-output.js
@@ -1,0 +1,10 @@
+const TodosList = DefineList.extend({
+  "#": class Model extends ObservableObject {
+    static get props() {
+      return {
+          id: "number",
+          name: "string"
+      };
+    }
+  }
+});

--- a/src/templates/can-observable-object/observable-object-test.js
+++ b/src/templates/can-observable-object/observable-object-test.js
@@ -22,4 +22,11 @@ describe('can-observable-object/observable-object', function() {
     utils.diffFiles(fn, inputPath, outputPath);
   });
 
+  it('Converts inline DefineMap.extend to class extends ObservableObject', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-inline-input.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-inline-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
 });

--- a/src/utils/defineTransform.js
+++ b/src/utils/defineTransform.js
@@ -32,17 +32,19 @@ export default function defineTransform ({
     let classPath;
     let refUpdate;
 
+    var parentPathValueType = path.parentPath && path.parentPath.value && path.parentPath.value.type;
+
     // Replace variable declarations with class def
-    if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'VariableDeclarator') {
+    if (parentPathValueType && (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'VariableDeclarator')) {
       varDeclaration = path.parentPath.value.id.name;
       classPath = path.parentPath.parentPath.parentPath;
     // Handle default exports
-    } else if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'ExportDefaultDeclaration') {
+    } else if (parentPathValueType && (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'ExportDefaultDeclaration')) {
         // If we have "default" export if the DefineMap or DefineList has two arguments, use the first as the name of the class
         // fallback to using `Model` if not
         varDeclaration = transformInlineMap(path);
         classPath = path;
-    } else if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'AssignmentExpression') {
+    } else if (parentPathValueType && (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'AssignmentExpression')) {
       classPath = path.parentPath.parentPath;
       // Use either the first argument if there are more than one
       // or use the expression ie. Message.List = DefineList {...}
@@ -56,7 +58,7 @@ export default function defineTransform ({
         objectName: path.parentPath.value.left.object.name,
         propertyName: path.parentPath.value.left.property.name
       };
-    } else if (path.parentPath.value.type === 'Property') {
+    } else if (parentPathValueType && path.parentPath.value.type === 'Property') {
       // Handle Define.extend as a property like '#': DefineMap.extend
       varDeclaration = transformInlineMap(path);
       classPath = path;

--- a/src/utils/defineTransform.js
+++ b/src/utils/defineTransform.js
@@ -1,6 +1,8 @@
 import { createClass, createMethod } from './classUtils';
 import replaceRefs from './replaceRefs';
 
+const transformInlineMap = (path) => path.value.arguments.length === 2 ?  path.value.arguments[0].value : 'Model';
+
 // can-define transform util
 // used to transform can-define/map & can-define/list
 export default function defineTransform ({
@@ -35,15 +37,10 @@ export default function defineTransform ({
       varDeclaration = path.parentPath.value.id.name;
       classPath = path.parentPath.parentPath.parentPath;
     // Handle default exports
-    } else if (path.parentPath && path.parentPath.value &&
-               path.parentPath.value.type === 'ExportDefaultDeclaration' ||
-               path.parentPath.value.type === 'Property'
-              ) {
+    } else if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'ExportDefaultDeclaration') {
         // If we have "default" export if the DefineMap or DefineList has two arguments, use the first as the name of the class
         // fallback to using `Model` if not
-        varDeclaration = path.value.arguments.length === 2 ?
-          path.value.arguments[0].value :
-          'Model';
+        varDeclaration = transformInlineMap(path);
         classPath = path;
     } else if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'AssignmentExpression') {
       classPath = path.parentPath.parentPath;
@@ -59,6 +56,10 @@ export default function defineTransform ({
         objectName: path.parentPath.value.left.object.name,
         propertyName: path.parentPath.value.left.property.name
       };
+    } else if (path.parentPath.value.type === 'Property') {
+      // Handle Define.extend as a property like '#': DefineMap.extend
+      varDeclaration = transformInlineMap(path);
+      classPath = path;
     }
 
     let propDefinitionsArg = path.value.arguments.length === 1 ?

--- a/src/utils/defineTransform.js
+++ b/src/utils/defineTransform.js
@@ -60,7 +60,7 @@ export default function defineTransform ({
       };
     } else if (parentPathValueType && path.parentPath.value.type === 'Property') {
       // Handle Define.extend as a property like '#': DefineMap.extend
-      varDeclaration = transformInlineMap(path);
+      // the class will be just class expression without a name
       classPath = path;
     }
 
@@ -86,7 +86,7 @@ export default function defineTransform ({
 
     const classDeclaration = createClass({
       j,
-      className: varDeclaration,
+      className: varDeclaration ? varDeclaration : '',
       body: [
         createMethod({
           j,

--- a/src/utils/defineTransform.js
+++ b/src/utils/defineTransform.js
@@ -35,7 +35,10 @@ export default function defineTransform ({
       varDeclaration = path.parentPath.value.id.name;
       classPath = path.parentPath.parentPath.parentPath;
     // Handle default exports
-    } else if (path.parentPath && path.parentPath.value && path.parentPath.value.type === 'ExportDefaultDeclaration') {
+    } else if (path.parentPath && path.parentPath.value &&
+               path.parentPath.value.type === 'ExportDefaultDeclaration' ||
+               path.parentPath.value.type === 'Property'
+              ) {
         // If we have "default" export if the DefineMap or DefineList has two arguments, use the first as the name of the class
         // fallback to using `Model` if not
         varDeclaration = path.value.arguments.length === 2 ?

--- a/test/fixtures/version-6/can-observable-object/observable-object-inline-input.js
+++ b/test/fixtures/version-6/can-observable-object/observable-object-inline-input.js
@@ -1,0 +1,6 @@
+const TodosList = DefineList.extend({
+  "#": DefineMap.extend({
+      id: "number",
+      name: "string"
+  })
+});

--- a/test/fixtures/version-6/can-observable-object/observable-object-inline-output.js
+++ b/test/fixtures/version-6/can-observable-object/observable-object-inline-output.js
@@ -1,5 +1,5 @@
 const TodosList = DefineList.extend({
-  "#": class Model extends ObservableObject {
+  "#": class  extends ObservableObject {
     static get props() {
       return {
           id: "number",

--- a/test/fixtures/version-6/can-observable-object/observable-object-inline-output.js
+++ b/test/fixtures/version-6/can-observable-object/observable-object-inline-output.js
@@ -1,0 +1,10 @@
+const TodosList = DefineList.extend({
+  "#": class Model extends ObservableObject {
+    static get props() {
+      return {
+          id: "number",
+          name: "string"
+      };
+    }
+  }
+});


### PR DESCRIPTION
This fixes inline `DefineMap` to `ObservableObject` transformation:

**From:** 
```js
const TodosList = DefineList.extend({
  "#": DefineMap.extend({
      id: "number",
      name: "string"
  })
});
```

**To:**

```js
const TodosList = DefineList.extend({
  "#": class Model extends ObservableObject {
    static get props() {
      return {
          id: "number",
          name: "string"
      };
    }
  }
});
```

Other codemods with lower order handle the rest of the transformations.

closes #148 
