### PR TITLE
Add split variable declarations

### DIFF
--- a/build/transforms.json
+++ b/build/transforms.json
@@ -1932,5 +1932,34 @@
         "version": "6"
       }
     ]
+  },
+  {
+    "copy": [
+      {
+        "input": "variable-declaration/chained-declaration.js",
+        "outputPath": "variable-declaration/chained-declaration.js",
+        "type": "transform",
+        "version": "6",
+        "order": 1
+      },
+      {
+        "input": "variable-declaration/chained-declaration-input.js",
+        "outputPath": "variable-declaration/chained-declaration-input.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "variable-declaration/chained-declaration-output.js",
+        "outputPath": "variable-declaration/chained-declaration-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "variable-declaration/chained-declaration-test.js",
+        "outputPath": "variable-declaration/chained-declaration-test.js",
+        "type": "test",
+        "version": "6"
+      }
+    ]
   }
 ]

--- a/build/transforms.json
+++ b/build/transforms.json
@@ -1955,6 +1955,18 @@
         "version": "6"
       },
       {
+        "input": "variable-declaration/chained-declaration-simple-input.js",
+        "outputPath": "variable-declaration/chained-declaration-simple-input.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
+        "input": "variable-declaration/chained-declaration-simple-output.js",
+        "outputPath": "variable-declaration/chained-declaration-simple-output.js",
+        "type": "fixture",
+        "version": "6"
+      },
+      {
         "input": "variable-declaration/chained-declaration-test.js",
         "outputPath": "variable-declaration/chained-declaration-test.js",
         "type": "test",

--- a/src/templates/variable-declaration/chained-declaration-input.js
+++ b/src/templates/variable-declaration/chained-declaration-input.js
@@ -1,0 +1,26 @@
+const Singleton = DefineMap.extend({
+  foo: "number",
+}),
+singleton = new Singleton({
+  foo: 2
+});
+
+var Foo = DefineMap.extend({
+  foo: "number",
+}),
+foo = new Foo({
+  foo: 2
+});
+
+/**
+ * @prop
+ */
+var Bar = DefineMap.extend({
+  foo: "number",
+}),
+/**
+ * @prop
+ */
+Bar = new Bar({
+  foo: 2
+});

--- a/src/templates/variable-declaration/chained-declaration-output.js
+++ b/src/templates/variable-declaration/chained-declaration-output.js
@@ -1,0 +1,29 @@
+const Singleton = DefineMap.extend({
+  foo: "number",
+});
+
+const singleton = new Singleton({
+  foo: 2
+});
+
+var Foo = DefineMap.extend({
+  foo: "number",
+});
+
+var foo = new Foo({
+  foo: 2
+});
+
+/**
+ * @prop
+ */
+var Bar = DefineMap.extend({
+  foo: "number",
+});
+
+/**
+ * @prop
+ */
+var Bar = new Bar({
+  foo: 2
+});

--- a/src/templates/variable-declaration/chained-declaration-simple-input.js
+++ b/src/templates/variable-declaration/chained-declaration-simple-input.js
@@ -1,0 +1,8 @@
+const foo = 'bar', baz = 'qux';
+
+let anObj = {}, anArray = [1, 2, 3];
+
+var anFn = function () {
+
+},
+aStr = 'qwerty';

--- a/src/templates/variable-declaration/chained-declaration-simple-output.js
+++ b/src/templates/variable-declaration/chained-declaration-simple-output.js
@@ -1,0 +1,8 @@
+const foo = 'bar', baz = 'qux';
+
+let anObj = {}, anArray = [1, 2, 3];
+
+var anFn = function () {
+
+},
+aStr = 'qwerty';

--- a/src/templates/variable-declaration/chained-declaration-test.js
+++ b/src/templates/variable-declaration/chained-declaration-test.js
@@ -15,4 +15,11 @@ describe('variable-declaration/chained-declaration', function() {
     utils.diffFiles(fn, inputPath, outputPath);
   });
 
+  it('Doesn not split chained var declaration DefineMap, DefineList and Component are not defined', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-simple-input.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-simple-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
 });

--- a/src/templates/variable-declaration/chained-declaration-test.js
+++ b/src/templates/variable-declaration/chained-declaration-test.js
@@ -1,0 +1,18 @@
+require('mocha');
+const utils = require('../../../../test/utils');
+const transforms = require('../../../../');
+
+const toTest = transforms.filter(function(transform) {
+  return transform.name === 'variable-declaration/chained-declaration.js';
+})[0];
+
+describe('variable-declaration/chained-declaration', function() {
+
+  it('splits chained var declaration', function() {
+    const fn = require(toTest.file);
+    const inputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-input.js')}`;
+    const outputPath = `fixtures/version-6/${toTest.fileName.replace('.js', '-output.js')}`;
+    utils.diffFiles(fn, inputPath, outputPath);
+  });
+
+});

--- a/src/templates/variable-declaration/chained-declaration.js
+++ b/src/templates/variable-declaration/chained-declaration.js
@@ -1,25 +1,61 @@
 import makeDebug from 'debug';
+import fileTransform from '../../../utils/fileUtil';
 
 export default function transformer(file, api) {
   const debug = makeDebug(`can-migrate:variable-declaration/chained-declaration:${file.path}`);
   const j = api.jscodeshift;
 
-  return j(file.source).find(j.VariableDeclaration).forEach(path => {
-    path.value.declarations.forEach(() => {
-      const kind = path.value.kind;
-      const unchainedDeclarations = path.value.declarations.map((declaration, i) => {
-      debug('Spliting chained variable declaration');
-      const unchainedDeclaration = j.variableDeclaration(kind, [declaration]);
-        // handle comments
-      if (i === 0) {
-        unchainedDeclaration.comments = path.value.comments;
-      } else if (declaration.comments) {
-        unchainedDeclaration.comments = declaration.comments;
-        declaration.comments = null;
+  return fileTransform(file, function (source) {
+    if (
+      hasDeclarations({j, source,  objectName: 'DefineMap'}) ||
+      hasDeclarations({j, source,  objectName: 'DefineList'}) ||
+      hasDeclarations({j, source,  objectName: 'Component'})
+     ) {
+
+      // Filter declarations except the declaration inside "for" statement
+      const chainedDeclarations = j(source)
+        .find(j.VariableDeclaration)
+        .filter(variableDeclaration => (
+          variableDeclaration.value.declarations.length > 1
+        ))
+        .filter(variableDeclaration => (
+          variableDeclaration.parent.value.type !== 'ForStatement'
+        ));
+
+      return chainedDeclarations.forEach(chainedDeclaration => {
+        const kind = chainedDeclaration.value.kind;
+        debug(`Splitting chained ${kind} declaration`);
+        j(chainedDeclaration)
+          .replaceWith(chainedDeclaration.value.declarations.map((declaration, i) => {
+            const unchainedDeclaration =
+              j.variableDeclaration(kind, [declaration]);
+
+            if (i === 0) {
+              unchainedDeclaration.comments = chainedDeclaration.value.comments;
+            } else if (declaration.comments) {
+              unchainedDeclaration.comments = declaration.comments;
+              declaration.comments = null;
+            }
+
+            return unchainedDeclaration;
+          }));
+      }).toSource();
+    }
+    return source.toSource();
+  });
+}
+
+function hasDeclarations({j, source,  objectName = 'DefineMap'} = {}) {
+  const declarations = j(source).find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      object: {
+        name: objectName
+      },
+      property: {
+        name: 'extend'
       }
-        return unchainedDeclaration;
-      });
-      j(path).replaceWith(unchainedDeclarations);
-    });
-  }).toSource();
+    }
+  });
+  return declarations.length > 0;
 }

--- a/src/templates/variable-declaration/chained-declaration.js
+++ b/src/templates/variable-declaration/chained-declaration.js
@@ -1,0 +1,25 @@
+import makeDebug from 'debug';
+
+export default function transformer(file, api) {
+  const debug = makeDebug(`can-migrate:variable-declaration/chained-declaration:${file.path}`);
+  const j = api.jscodeshift;
+
+  return j(file.source).find(j.VariableDeclaration).forEach(path => {
+    path.value.declarations.forEach(() => {
+      const kind = path.value.kind;
+      const unchainedDeclarations = path.value.declarations.map((declaration, i) => {
+      debug('Spliting chained variable declaration');
+      const unchainedDeclaration = j.variableDeclaration(kind, [declaration]);
+        // handle comments
+      if (i === 0) {
+        unchainedDeclaration.comments = path.value.comments;
+      } else if (declaration.comments) {
+        unchainedDeclaration.comments = declaration.comments;
+        declaration.comments = null;
+      }
+        return unchainedDeclaration;
+      });
+      j(path).replaceWith(unchainedDeclarations);
+    });
+  }).toSource();
+}

--- a/test/fixtures/version-6/variable-declaration/chained-declaration-input.js
+++ b/test/fixtures/version-6/variable-declaration/chained-declaration-input.js
@@ -1,0 +1,26 @@
+const Singleton = DefineMap.extend({
+  foo: "number",
+}),
+singleton = new Singleton({
+  foo: 2
+});
+
+var Foo = DefineMap.extend({
+  foo: "number",
+}),
+foo = new Foo({
+  foo: 2
+});
+
+/**
+ * @prop
+ */
+var Bar = DefineMap.extend({
+  foo: "number",
+}),
+/**
+ * @prop
+ */
+Bar = new Bar({
+  foo: 2
+});

--- a/test/fixtures/version-6/variable-declaration/chained-declaration-output.js
+++ b/test/fixtures/version-6/variable-declaration/chained-declaration-output.js
@@ -1,0 +1,29 @@
+const Singleton = DefineMap.extend({
+  foo: "number",
+});
+
+const singleton = new Singleton({
+  foo: 2
+});
+
+var Foo = DefineMap.extend({
+  foo: "number",
+});
+
+var foo = new Foo({
+  foo: 2
+});
+
+/**
+ * @prop
+ */
+var Bar = DefineMap.extend({
+  foo: "number",
+});
+
+/**
+ * @prop
+ */
+var Bar = new Bar({
+  foo: 2
+});

--- a/test/fixtures/version-6/variable-declaration/chained-declaration-simple-input.js
+++ b/test/fixtures/version-6/variable-declaration/chained-declaration-simple-input.js
@@ -1,0 +1,8 @@
+const foo = 'bar', baz = 'qux';
+
+let anObj = {}, anArray = [1, 2, 3];
+
+var anFn = function () {
+
+},
+aStr = 'qwerty';

--- a/test/fixtures/version-6/variable-declaration/chained-declaration-simple-output.js
+++ b/test/fixtures/version-6/variable-declaration/chained-declaration-simple-output.js
@@ -1,0 +1,8 @@
+const foo = 'bar', baz = 'qux';
+
+let anObj = {}, anArray = [1, 2, 3];
+
+var anFn = function () {
+
+},
+aStr = 'qwerty';

--- a/test/test.js
+++ b/test/test.js
@@ -126,3 +126,4 @@ require('../lib/transforms/version-6/can-property-definitions/observable-default
 require('../lib/transforms/version-6/can-property-definitions/observable-object-stache-element-sealed-test.js');
 require('../lib/transforms/version-6/can-rest-model/map-list-test.js');
 require('../lib/transforms/version-6/can-rest-model/map-list-shorthand-test.js');
+require('../lib/transforms/version-6/variable-declaration/chained-declaration-test.js');


### PR DESCRIPTION
Add chained variable splitting codemod:
From 

```js
const Singleton = DefineMap.extend({
  foo: "number",
}),
singleton = new Singleton({
  foo: 2
});

var Foo = DefineMap.extend({
  foo: "number",
}),
foo = new Foo({
  foo: 2
});

/**
 * @prop
 */
var Bar = DefineMap.extend({
  foo: "number",
}),
/**
 * @prop
 */
Bar = new Bar({
  foo: 2
});
```
To 
```js
const Singleton = DefineMap.extend({
  foo: "number",
});

const singleton = new Singleton({
  foo: 2
});

var Foo = DefineMap.extend({
  foo: "number",
});

var foo = new Foo({
  foo: 2
});

/**
 * @prop
 */
var Bar = DefineMap.extend({
  foo: "number",
});

/**
 * @prop
 */
var Bar = new Bar({
  foo: 2
});
```
Closes #156