### PR TITLE
Upgrade stache bindings with old key="{value}" and can-event/can-value syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: "14"
 dist: xenial
 services:
   - xvfb

--- a/src/templates/can-stache-bindings/colon-bindings.js
+++ b/src/templates/can-stache-bindings/colon-bindings.js
@@ -6,7 +6,7 @@ var kebabToCamel = function (kebab) {
 
 var detectCanValueRE = /<[^>]*\bcan-value=[^>]*>/g;
 var detectCanHrefRE = /\bcan-href=[^>]*>/g;
-var detectCanEventRE = /\bcan-(\w[-:\w]+)=(\\?")([^\n"]+?)\\?"/g;
+var detectCanEventRE = /\bcan-(\w[-:\w]+)=(\\?") *\{*([^\n"]+?)\}* *\\?"/g;
 var detectBraceDelimitedValueRE = /([-\w:]+)=(\\?")\{(?!\{)([^}\n"]+)\}\\?"/g;
 
 var cvTypeRE = /\btype=\\?"([^"]*?)\\?"/;
@@ -69,6 +69,7 @@ function makeCanEventProcessor(explicit) {
     var tokens;
     if (!hasCallExpr) {
       if(hasParams) {
+
         tokens = $2.split(' ').map(function(token) {
           return {
             str: token,

--- a/src/templates/can-stache-bindings/colon-bindings.js
+++ b/src/templates/can-stache-bindings/colon-bindings.js
@@ -5,6 +5,18 @@ var kebabToCamel = function (kebab) {
 };
 
 var transformStacheExplicit = function (src) {
+  // older legacy binding.
+  src = src.replace(/([-\w:]+)="\{([^}\n"]+)\}"/g, function (x, $1, $2) {
+    return 'vm:' + kebabToCamel($1) + ':from="' + $2 + '"';
+  });
+  src = src.replace(/\bcan-(\w[-\w]+)=/g, function (x, $1) {
+    if($1.toLowerCase() === 'value') {
+      return 'el:' + kebabToCamel($1) + ':bind=';
+    } else {
+      return 'on:el:' + kebabToCamel($1) + '=';
+    }
+  });
+
   src = src.replace(/\{\^\$([^}\n]+)\}=/g, function (x, $1) {
     return 'el:' + kebabToCamel($1) + ':to=';
   });
@@ -37,6 +49,18 @@ var transformStacheExplicit = function (src) {
 };
 
 var transformStacheContextIntuitive = function (src) {
+  // older legacy binding.
+  src = src.replace(/([-\w:]+)="\{([^}\n"]+)\}"/g, function (x, $1, $2) {
+    return kebabToCamel($1) + ':from="' + $2 + '"';
+  });
+  src = src.replace(/\bcan-(\w[-\w]+)=/g, function (x, $1) {
+    if($1.toLowerCase() === 'value') {
+      return kebabToCamel($1) + ':bind=';
+    } else {
+      return 'on:' + kebabToCamel($1) + '=';
+    }
+  });
+
   src = src.replace(/\{\^\$?([^}\n]+)\}=/g, function (x, $1) {
     return kebabToCamel($1) + ':to=';
   });

--- a/src/templates/can-stache-bindings/input.component
+++ b/src/templates/can-stache-bindings/input.component
@@ -1,7 +1,7 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -12,7 +12,7 @@
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.component
+++ b/src/templates/can-stache-bindings/input.component
@@ -1,11 +1,23 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </view>
 
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/input.component
+++ b/src/templates/can-stache-bindings/input.component
@@ -1,7 +1,8 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -12,7 +13,8 @@
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.html
+++ b/src/templates/can-stache-bindings/input.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/input.html
+++ b/src/templates/can-stache-bindings/input.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.html
+++ b/src/templates/can-stache-bindings/input.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.js
+++ b/src/templates/can-stache-bindings/input.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+    'value="{H1}" can-click="H3" ' +
+    'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
     '<input can-value="H1">' +
     '<input type="checkbox" can-value="H2" />' +
     '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.js
+++ b/src/templates/can-stache-bindings/input.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-value="H2" can-click="H3">'
+    'value="{H1}" can-click="H3">' +
+    '<input can-value="H1">' +
+    '<input type="checkbox" can-value="H2" />' +
+    '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+    '<input type="radio" can-value="H4" />' +
+    '<input type="radio" can-value="H5" value="thisOne" />'
   )
 });

--- a/src/templates/can-stache-bindings/input.js
+++ b/src/templates/can-stache-bindings/input.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-click="H3">' +
+    'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
     '<input can-value="H1">' +
     '<input type="checkbox" can-value="H2" />' +
     '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/src/templates/can-stache-bindings/input.js
+++ b/src/templates/can-stache-bindings/input.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+    'value="{H1}" can-value="H2" can-click="H3">'
   )
 });

--- a/src/templates/can-stache-bindings/input.md
+++ b/src/templates/can-stache-bindings/input.md
@@ -1,7 +1,8 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+  value="{H1}" can-click="H3"
+  can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
+    "value=\"{H1}\" can-click=\"H3\" " +
+    "can-hover=\"{H5}\" can-enter=\"H4 foo bar='baz' thud=quux\"> " +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
+    "value=\"{H1}\" can-click=\"H3\" " +
+    "can-hover=\"{H5}\" can-enter=\"H4 foo bar='baz' thud=quux\"> " +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +

--- a/src/templates/can-stache-bindings/input.md
+++ b/src/templates/can-stache-bindings/input.md
@@ -1,24 +1,42 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+  value="{H1}" can-click="H3">
+<input can-value="H1">
+<input type="checkbox" can-value="H2" />
+<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+<input type="radio" can-value="H4" />
+<input type="radio" can-value="H5" value="thisOne" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
-    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
+    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
+    "value=\"{H1}\" can-click=\"H3\">" +
+    "<input can-value=\"H1\">" +
+    "<input type=\"checkbox\" can-value=\"H2\" />" +
+    "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
+    "<input type=\"radio\" can-value=\"H4\" />" +
+    "<input type=\"radio\" can-value=\"H5\" value=\"thisOne\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
-    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
+    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
+    "value=\"{H1}\" can-click=\"H3\">" +
+    "<input can-value=\"H1\">" +
+    "<input type=\"checkbox\" can-value=\"H2\" />" +
+    "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
+    "<input type=\"radio\" can-value=\"H4\" />" +
+    "<input type=\"radio\" can-value=\"H5\" value=\"thisOne\" />"
+  )
 } );
 ```

--- a/src/templates/can-stache-bindings/input.md
+++ b/src/templates/can-stache-bindings/input.md
@@ -1,7 +1,7 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3">
+  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\">" +
+    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\">" +
+    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +

--- a/src/templates/can-stache-bindings/input.stache
+++ b/src/templates/can-stache-bindings/input.stache
@@ -1,6 +1,6 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3">
+  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>

--- a/src/templates/can-stache-bindings/input.stache
+++ b/src/templates/can-stache-bindings/input.stache
@@ -1,2 +1,8 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+  value="{H1}" can-click="H3">
+<input can-value="H1">
+<input type="checkbox" can-value="H2" />
+<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+<input type="radio" can-value="H4" />
+<input type="radio" can-value="H5" value="thisOne" />

--- a/src/templates/can-stache-bindings/input.stache
+++ b/src/templates/can-stache-bindings/input.stache
@@ -1,6 +1,7 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+  value="{H1}" can-click="H3"
+  can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>

--- a/src/templates/can-stache-bindings/output-implicit.component
+++ b/src/templates/can-stache-bindings/output-implicit.component
@@ -1,11 +1,23 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </view>
 
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/output-implicit.component
+++ b/src/templates/can-stache-bindings/output-implicit.component
@@ -1,7 +1,7 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +12,7 @@
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.component
+++ b/src/templates/can-stache-bindings/output-implicit.component
@@ -1,7 +1,8 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +13,8 @@
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.html
+++ b/src/templates/can-stache-bindings/output-implicit.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/output-implicit.html
+++ b/src/templates/can-stache-bindings/output-implicit.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.html
+++ b/src/templates/can-stache-bindings/output-implicit.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.js
+++ b/src/templates/can-stache-bindings/output-implicit.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+    'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+    'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input value:bind="H1">' +
     '<input type="checkbox" checked:bind="H2" />' +
     '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.js
+++ b/src/templates/can-stache-bindings/output-implicit.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" on:click="H3">' +
+    'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input value:bind="H1">' +
     '<input type="checkbox" checked:bind="H2" />' +
     '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output-implicit.js
+++ b/src/templates/can-stache-bindings/output-implicit.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" value:bind="H2" on:click="H3">'
+    'value:from="H1" on:click="H3">' +
+    '<input value:bind="H1">' +
+    '<input type="checkbox" checked:bind="H2" />' +
+    '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+    '<input type="radio" checked:bind="H4" />' +
+    '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
   )
 });

--- a/src/templates/can-stache-bindings/output-implicit.js
+++ b/src/templates/can-stache-bindings/output-implicit.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:from="H1" value:bind="H2" on:click="H3">'
   )
 });

--- a/src/templates/can-stache-bindings/output-implicit.md
+++ b/src/templates/can-stache-bindings/output-implicit.md
@@ -1,24 +1,42 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:from="H1" on:click="H3">
+<input value:bind="H1">
+<input type="checkbox" checked:bind="H2" />
+<input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" checked:bind="H4" />
+<input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:from=\"H1\" on:click=\"H3\">" +
+    "<input value:bind=\"H1\">" +
+    "<input type=\"checkbox\" checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:from=\"H1\" on:click=\"H3\">" +
+    "<input value:bind=\"H1\">" +
+    "<input type=\"checkbox\" checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```

--- a/src/templates/can-stache-bindings/output-implicit.md
+++ b/src/templates/can-stache-bindings/output-implicit.md
@@ -1,7 +1,7 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/src/templates/can-stache-bindings/output-implicit.md
+++ b/src/templates/can-stache-bindings/output-implicit.md
@@ -1,7 +1,8 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)"
+  on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:hover=\"H5(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:hover=\"H5(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/src/templates/can-stache-bindings/output-implicit.stache
+++ b/src/templates/can-stache-bindings/output-implicit.stache
@@ -1,2 +1,8 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:from="H1" on:click="H3">
+<input value:bind="H1">
+<input type="checkbox" checked:bind="H2" />
+<input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" checked:bind="H4" />
+<input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />

--- a/src/templates/can-stache-bindings/output-implicit.stache
+++ b/src/templates/can-stache-bindings/output-implicit.stache
@@ -1,6 +1,6 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/src/templates/can-stache-bindings/output-implicit.stache
+++ b/src/templates/can-stache-bindings/output-implicit.stache
@@ -1,6 +1,7 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)"
+  on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/src/templates/can-stache-bindings/output.component
+++ b/src/templates/can-stache-bindings/output.component
@@ -1,7 +1,8 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +13,8 @@
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.component
+++ b/src/templates/can-stache-bindings/output.component
@@ -1,7 +1,7 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +12,7 @@
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.component
+++ b/src/templates/can-stache-bindings/output.component
@@ -1,11 +1,23 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </view>
 
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/output.html
+++ b/src/templates/can-stache-bindings/output.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.html
+++ b/src/templates/can-stache-bindings/output.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/src/templates/can-stache-bindings/output.html
+++ b/src/templates/can-stache-bindings/output.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.js
+++ b/src/templates/can-stache-bindings/output.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+    'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input el:value:bind="H1">' +
     '<input type="checkbox" el:checked:bind="H2" />' +
     '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.js
+++ b/src/templates/can-stache-bindings/output.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" on:el:click="H3">' +
+    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input el:value:bind="H1">' +
     '<input type="checkbox" el:checked:bind="H2" />' +
     '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/src/templates/can-stache-bindings/output.js
+++ b/src/templates/can-stache-bindings/output.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+    'vm:value:from="H1" el:value:bind="H2" on:el:click="H3">'
   )
 });

--- a/src/templates/can-stache-bindings/output.js
+++ b/src/templates/can-stache-bindings/output.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" el:value:bind="H2" on:el:click="H3">'
+    'vm:value:from="H1" on:el:click="H3">' +
+    '<input el:value:bind="H1">' +
+    '<input type="checkbox" el:checked:bind="H2" />' +
+    '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+    '<input type="radio" el:checked:bind="H4" />' +
+    '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
   )
 });

--- a/src/templates/can-stache-bindings/output.md
+++ b/src/templates/can-stache-bindings/output.md
@@ -1,7 +1,8 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+  on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:el:hover=\"H5(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:el:hover=\"H5(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/src/templates/can-stache-bindings/output.md
+++ b/src/templates/can-stache-bindings/output.md
@@ -1,7 +1,7 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/src/templates/can-stache-bindings/output.md
+++ b/src/templates/can-stache-bindings/output.md
@@ -1,24 +1,42 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+  vm:value:from="H1" on:el:click="H3">
+<input el:value:bind="H1">
+<input type="checkbox" el:checked:bind="H2" />
+<input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" el:checked:bind="H4" />
+<input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
-    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
+    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
+    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "<input el:value:bind=\"H1\">" +
+    "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" el:checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" el:checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
-    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
+    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
+    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "<input el:value:bind=\"H1\">" +
+    "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" el:checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" el:checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```

--- a/src/templates/can-stache-bindings/output.stache
+++ b/src/templates/can-stache-bindings/output.stache
@@ -1,2 +1,8 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+  vm:value:from="H1" on:el:click="H3">
+<input el:value:bind="H1">
+<input type="checkbox" el:checked:bind="H2" />
+<input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" el:checked:bind="H4" />
+<input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />

--- a/src/templates/can-stache-bindings/output.stache
+++ b/src/templates/can-stache-bindings/output.stache
@@ -1,6 +1,7 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+  on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/src/templates/can-stache-bindings/output.stache
+++ b/src/templates/can-stache-bindings/output.stache
@@ -1,6 +1,6 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/src/templates/can-stache/scope-input.stache
+++ b/src/templates/can-stache/scope-input.stache
@@ -5,6 +5,16 @@
   {{%event}}
   {{%viewModel}}
   {{%arguments}}
+  {{%scope}}
+  {{@index}}
+  {{@key}}
+  {{@element}}
+  {{@event}}
+  {{@viewModel}}
+  {{@arguments}}
+  {{@scope}}
+  {{%context}}
+  {{@context}}
 </p>
 
 <p>
@@ -14,4 +24,14 @@
   {{%event}}
   {{%viewModel}}
   {{%arguments}}
+  {{%scope}}
+  {{@index}}
+  {{@key}}
+  {{@element}}
+  {{@event}}
+  {{@viewModel}}
+  {{@arguments}}
+  {{@scope}}
+  {{%context}}
+  {{@context}}
 </p>

--- a/src/templates/can-stache/scope-output.stache
+++ b/src/templates/can-stache/scope-output.stache
@@ -5,6 +5,16 @@
   {{scope.event}}
   {{scope.viewModel}}
   {{scope.arguments}}
+  {{scope.scope}}
+  {{scope.index}}
+  {{scope.key}}
+  {{scope.element}}
+  {{scope.event}}
+  {{scope.viewModel}}
+  {{scope.arguments}}
+  {{scope.scope}}
+  {{this}}
+  {{this}}
 </p>
 
 <p>
@@ -14,4 +24,14 @@
   {{scope.event}}
   {{scope.viewModel}}
   {{scope.arguments}}
+  {{scope.scope}}
+  {{scope.index}}
+  {{scope.key}}
+  {{scope.element}}
+  {{scope.event}}
+  {{scope.viewModel}}
+  {{scope.arguments}}
+  {{scope.scope}}
+  {{this}}
+  {{this}}
 </p>

--- a/src/templates/can-stache/scope.js
+++ b/src/templates/can-stache/scope.js
@@ -2,12 +2,8 @@
 export default function transformer(file) {
   let src = file.source;
 
-  src = src.replace(/%index/g, 'scope.index');
-  src = src.replace(/%key/g, 'scope.key');
-  src = src.replace(/%element/g, 'scope.element');
-  src = src.replace(/%event/g, 'scope.event');
-  src = src.replace(/%viewModel/g, 'scope.viewModel');
-  src = src.replace(/%arguments/g, 'scope.arguments');
+  src = src.replace(/[@%](index|key|element|event|viewModel|scope|arguments)\b/g, 'scope.$1');
+  src = src.replace(/[@%]context/g, 'this');
 
   return src;
 }

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
@@ -1,7 +1,7 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -12,7 +12,7 @@
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
@@ -1,11 +1,23 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </view>
 
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.component
@@ -1,7 +1,8 @@
 <view>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -12,7 +13,8 @@
 <template>
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+    {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+    value="{H1}" can-click="H3">
+  <input can-value="H1">
+  <input type="checkbox" can-value="H2" />
+  <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+  <input type="radio" can-value="H4" />
+  <input type="radio" can-value="H5" value="thisOne" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+      '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+      'value="{H1}" can-click="H3">' +
+      '<input can-value="H1">' +
+      '<input type="checkbox" can-value="H2" />' +
+      '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+      '<input type="radio" can-value="H4" />' +
+      '<input type="radio" can-value="H5" value="thisOne" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+    value="{H1}" can-click="H3"
+    can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+      'value="{H1}" can-click="H3" ' +
+      'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
     {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-    value="{H1}" can-click="H3">
+    value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
   <input can-value="H1">
   <input type="checkbox" can-value="H2" />
   <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
       '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-      'value="{H1}" can-click="H3">' +
+      'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
       '<input can-value="H1">' +
       '<input type="checkbox" can-value="H2" />' +
       '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
+    'value="{H1}" can-click="H3" ' +
+    'can-hover="{H5}" can-enter="H4 foo bar=\'baz\' thud=quux">' +
     '<input can-value="H1">' +
     '<input type="checkbox" can-value="H2" />' +
     '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-value="H2" can-click="H3">'
+    'value="{H1}" can-click="H3">' +
+    '<input can-value="H1">' +
+    '<input type="checkbox" can-value="H2" />' +
+    '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +
+    '<input type="radio" can-value="H4" />' +
+    '<input type="radio" can-value="H5" value="thisOne" />'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
     '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
-    'value="{H1}" can-click="H3">' +
+    'value="{H1}" can-click="H3" can-enter="H4 foo bar=\'baz\' thud=quux">' +
     '<input can-value="H1">' +
     '<input type="checkbox" can-value="H2" />' +
     '<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4" ' +
-    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">'
+    '{^value}="H1" {value}="H2" {(value)}="H3" (value)="H4" ' +
+    'value="{H1}" can-value="H2" can-click="H3">'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
@@ -1,7 +1,8 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+  value="{H1}" can-click="H3"
+  can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
+    "value=\"{H1}\" can-click=\"H3\" " +
+    "can-hover=\"{H5}\" can-enter=\"H4 foo bar='baz' thud=quux\"> " +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
+    "value=\"{H1}\" can-click=\"H3\" " +
+    "can-hover=\"{H5}\" can-enter=\"H4 foo bar='baz' thud=quux\"> " +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
@@ -1,24 +1,42 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+  value="{H1}" can-click="H3">
+<input can-value="H1">
+<input type="checkbox" can-value="H2" />
+<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+<input type="radio" can-value="H4" />
+<input type="radio" can-value="H5" value="thisOne" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
-    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
+    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
+    "value=\"{H1}\" can-click=\"H3\">" +
+    "<input can-value=\"H1\">" +
+    "<input type=\"checkbox\" can-value=\"H2\" />" +
+    "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
+    "<input type=\"radio\" can-value=\"H4\" />" +
+    "<input type=\"radio\" can-value=\"H5\" value=\"thisOne\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
-    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
+    "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
+    "value=\"{H1}\" can-click=\"H3\">" +
+    "<input can-value=\"H1\">" +
+    "<input type=\"checkbox\" can-value=\"H2\" />" +
+    "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
+    "<input type=\"radio\" can-value=\"H4\" />" +
+    "<input type=\"radio\" can-value=\"H5\" value=\"thisOne\" />"
+  )
 } );
 ```

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.md
@@ -1,7 +1,7 @@
 ```html
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3">
+  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\">" +
+    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input {^$value}=\"H1\" {$value}=\"H2\" {($value)}=\"H3\" ($value)=\"H4\" " +
     "{^value}=\"H1\" {value}=\"H2\" {(value)}=\"H3\" (value)=\"H4\" " +
-    "value=\"{H1}\" can-click=\"H3\">" +
+    "value=\"{H1}\" can-click=\"H3\" can-enter=\"H4 foo bar='baz' thud=quux\">" +
     "<input can-value=\"H1\">" +
     "<input type=\"checkbox\" can-value=\"H2\" />" +
     "<input type=\"checkbox\" can-value=\"H3\" can-true-value=\"Y\" can-false-value=\"N\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
@@ -1,6 +1,6 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3">
+  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
@@ -1,2 +1,8 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
-  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4">
+  {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
+  value="{H1}" can-click="H3">
+<input can-value="H1">
+<input type="checkbox" can-value="H2" />
+<input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>
+<input type="radio" can-value="H4" />
+<input type="radio" can-value="H5" value="thisOne" />

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-input.stache
@@ -1,6 +1,7 @@
 <input {^$value}="H1" {$value}="H2" {($value)}="H3" ($value)="H4"
   {^value}="H1" {value}="H2" {(value)}="H3" (value)="H4"
-  value="{H1}" can-click="H3" can-enter="H4 foo bar='baz' thud=quux">
+  value="{H1}" can-click="H3"
+  can-hover="{H5}" can-enter="H4 foo bar='baz' thud=quux">
 <input can-value="H1">
 <input type="checkbox" can-value="H2" />
 <input type="checkbox" can-value="H3" can-true-value="Y" can-false-value="N"/>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
@@ -1,11 +1,23 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </view>
 
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
@@ -1,7 +1,7 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +12,7 @@
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.component
@@ -1,7 +1,8 @@
 <view>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +13,8 @@
 <template>
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+    value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+    value:from="H1" on:click="H3">
+  <input value:bind="H1">
+  <input type="checkbox" checked:bind="H2" />
+  <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" checked:bind="H4" />
+  <input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+      'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+      'value:from="H1" on:click="H3">' +
+      '<input value:bind="H1">' +
+      '<input type="checkbox" checked:bind="H2" />' +
+      '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
     value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-    value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+    value:from="H1" on:click="H3(this, scope.element, scope.event)"
+    on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
   <input value:bind="H1">
   <input type="checkbox" checked:bind="H2" />
   <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
       'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-      'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+      'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input value:bind="H1">' +
       '<input type="checkbox" checked:bind="H2" />' +
       '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+    'value:from="H1" on:click="H3(this, scope.element, scope.event)" ' +
+    'on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input value:bind="H1">' +
     '<input type="checkbox" checked:bind="H2" />' +
     '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" on:click="H3">' +
+    'value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input value:bind="H1">' +
     '<input type="checkbox" checked:bind="H2" />' +
     '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
     'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:from="H1" value:bind="H2" on:click="H3">'
+    'value:from="H1" on:click="H3">' +
+    '<input value:bind="H1">' +
+    '<input type="checkbox" checked:bind="H2" />' +
+    '<input type="checkbox" checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+    '<input type="radio" checked:bind="H4" />' +
+    '<input type="radio" value="thisOne" checked:bind="equal(H5, \'thisOne\')" />'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
-    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4">'
+    'value:to="H1" value:from="H2" value:bind="H3" on:value="H4" ' +
+    'value:from="H1" value:bind="H2" on:click="H3">'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
@@ -1,24 +1,42 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:from="H1" on:click="H3">
+<input value:bind="H1">
+<input type="checkbox" checked:bind="H2" />
+<input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" checked:bind="H4" />
+<input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:from=\"H1\" on:click=\"H3\">" +
+    "<input value:bind=\"H1\">" +
+    "<input type=\"checkbox\" checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
+    "value:from=\"H1\" on:click=\"H3\">" +
+    "<input value:bind=\"H1\">" +
+    "<input type=\"checkbox\" checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
@@ -1,7 +1,7 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.md
@@ -1,7 +1,8 @@
 ```html
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)"
+  on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:hover=\"H5(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
     "value:to=\"H1\" value:from=\"H2\" value:bind=\"H3\" on:value=\"H4\" " +
-    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "value:from=\"H1\" on:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:hover=\"H5(this, scope.element, scope.event)\" on:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input value:bind=\"H1\">" +
     "<input type=\"checkbox\" checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
@@ -1,2 +1,8 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:to="H1" value:from="H2" value:bind="H3" on:value="H4">
+  value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
+  value:from="H1" on:click="H3">
+<input value:bind="H1">
+<input type="checkbox" checked:bind="H2" />
+<input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" checked:bind="H4" />
+<input type="radio" value="thisOne" checked:bind="equal(H5, 'thisOne')" />

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
@@ -1,6 +1,6 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output-implicit.stache
@@ -1,6 +1,7 @@
 <input value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
   value:to="H1" value:from="H2" value:bind="H3" on:value="H4"
-  value:from="H1" on:click="H3(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
+  value:from="H1" on:click="H3(this, scope.element, scope.event)"
+  on:hover="H5(this, scope.element, scope.event)" on:enter="H4(foo, bar='baz' thud=quux)">
 <input value:bind="H1">
 <input type="checkbox" checked:bind="H2" />
 <input type="checkbox" checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
@@ -1,7 +1,8 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +13,8 @@
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +28,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +45,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
@@ -1,7 +1,7 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -12,7 +12,7 @@
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -26,7 +26,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
@@ -42,7 +42,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.component
@@ -1,11 +1,23 @@
 <view>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </view>
 
 <template>
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </template>
 
 <view-model>
@@ -13,7 +25,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </view-model>
@@ -23,7 +41,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
@@ -1,7 +1,7 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
@@ -1,6 +1,12 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+    vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+    vm:value:from="H1" on:el:click="H3">
+  <input el:value:bind="H1">
+  <input type="checkbox" el:checked:bind="H2" />
+  <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+  <input type="radio" el:checked:bind="H4" />
+  <input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 </script>
 
 <script src="../foo/bar/steal/steal.js">
@@ -8,7 +14,13 @@
     tag: 'my-tag',
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+      'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+      'vm:value:from="H1" on:el:click="H3">' +
+      '<input el:value:bind="H1">' +
+      '<input type="checkbox" el:checked:bind="H2" />' +
+      '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+      '<input type="radio" el:checked:bind="H4" />' +
+      '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
     )
   });
 </script>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.html
@@ -1,7 +1,8 @@
 <script type="text/stache">
   <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
     vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+    vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+    on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
   <input el:value:bind="H1">
   <input type="checkbox" el:checked:bind="H2" />
   <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@
     template: stache(
       '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
       'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+      'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+      'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
       '<input el:value:bind="H1">' +
       '<input type="checkbox" el:checked:bind="H2" />' +
       '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
@@ -3,7 +3,8 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
+    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" ' +
+    'on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input el:value:bind="H1">' +
     '<input type="checkbox" el:checked:bind="H2" />' +
     '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
@@ -3,7 +3,7 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" on:el:click="H3">' +
+    'vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar=\'baz\' thud=quux)">' +
     '<input el:value:bind="H1">' +
     '<input type="checkbox" el:checked:bind="H2" />' +
     '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
@@ -2,6 +2,7 @@ Component.extend({
   tag: 'my-tag',
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
-    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">'
+    'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
+    'vm:value:from="H1" el:value:bind="H2" on:el:click="H3">'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.js
@@ -3,6 +3,11 @@ Component.extend({
   template: stache(
     '<input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4" ' +
     'vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4" ' +
-    'vm:value:from="H1" el:value:bind="H2" on:el:click="H3">'
+    'vm:value:from="H1" on:el:click="H3">' +
+    '<input el:value:bind="H1">' +
+    '<input type="checkbox" el:checked:bind="H2" />' +
+    '<input type="checkbox" el:checked:bind="either-or(H3, \'Y\', \'N\')"/>' +
+    '<input type="radio" el:checked:bind="H4" />' +
+    '<input type="radio" value="thisOne" el:checked:bind="equal(H5, \'thisOne\')" />'
   )
 });

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
@@ -1,7 +1,8 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+  on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +16,8 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:el:hover=\"H5(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +33,8 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" " +
+    "on:el:hover=\"H5(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\"> " +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
@@ -1,7 +1,7 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
@@ -15,7 +15,7 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
@@ -31,7 +31,7 @@ Component.extend( {
   template: stache(
     "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
     "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
-    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "vm:value:from=\"H1\" on:el:click=\"H3(this, scope.element, scope.event)\" on:el:enter=\"H4(foo, bar='baz' thud=quux)\">" +
     "<input el:value:bind=\"H1\">" +
     "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
     "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.md
@@ -1,24 +1,42 @@
 ```html
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+  vm:value:from="H1" on:el:click="H3">
+<input el:value:bind="H1">
+<input type="checkbox" el:checked:bind="H2" />
+<input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" el:checked:bind="H4" />
+<input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />
 ```
 
 ```js
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
-    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
+    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
+    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "<input el:value:bind=\"H1\">" +
+    "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" el:checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" el:checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```
 
 ```javascript
 Component.extend( {
-	tag: "my-tag",
-	template: stache(
-		"<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
-    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\">"
-	)
+  tag: "my-tag",
+  template: stache(
+    "<input el:value:to=\"H1\" el:value:from=\"H2\" el:value:bind=\"H3\" on:el:value=\"H4\" " +
+    "vm:value:to=\"H1\" vm:value:from=\"H2\" vm:value:bind=\"H3\" on:vm:value=\"H4\" " +
+    "vm:value:from=\"H1\" on:el:click=\"H3\">" +
+    "<input el:value:bind=\"H1\">" +
+    "<input type=\"checkbox\" el:checked:bind=\"H2\" />" +
+    "<input type=\"checkbox\" el:checked:bind=\"either-or(H3, 'Y', 'N')\"/>" +
+    "<input type=\"radio\" el:checked:bind=\"H4\" />" +
+    "<input type=\"radio\" value=\"thisOne\" el:checked:bind=\"equal(H5, 'thisOne')\" />"
+  )
 } );
 ```

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
@@ -1,2 +1,8 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
-  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4">
+  vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
+  vm:value:from="H1" on:el:click="H3">
+<input el:value:bind="H1">
+<input type="checkbox" el:checked:bind="H2" />
+<input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>
+<input type="radio" el:checked:bind="H4" />
+<input type="radio" value="thisOne" el:checked:bind="equal(H5, 'thisOne')" />

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
@@ -1,6 +1,7 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)"
+  on:el:hover="H5(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
+++ b/test/fixtures/version-3/can-stache-bindings/colon-bindings-output.stache
@@ -1,6 +1,6 @@
 <input el:value:to="H1" el:value:from="H2" el:value:bind="H3" on:el:value="H4"
   vm:value:to="H1" vm:value:from="H2" vm:value:bind="H3" on:vm:value="H4"
-  vm:value:from="H1" on:el:click="H3">
+  vm:value:from="H1" on:el:click="H3(this, scope.element, scope.event)" on:el:enter="H4(foo, bar='baz' thud=quux)">
 <input el:value:bind="H1">
 <input type="checkbox" el:checked:bind="H2" />
 <input type="checkbox" el:checked:bind="either-or(H3, 'Y', 'N')"/>

--- a/test/fixtures/version-4/can-stache/scope-input.stache
+++ b/test/fixtures/version-4/can-stache/scope-input.stache
@@ -5,6 +5,16 @@
   {{%event}}
   {{%viewModel}}
   {{%arguments}}
+  {{%scope}}
+  {{@index}}
+  {{@key}}
+  {{@element}}
+  {{@event}}
+  {{@viewModel}}
+  {{@arguments}}
+  {{@scope}}
+  {{%context}}
+  {{@context}}
 </p>
 
 <p>
@@ -14,4 +24,14 @@
   {{%event}}
   {{%viewModel}}
   {{%arguments}}
+  {{%scope}}
+  {{@index}}
+  {{@key}}
+  {{@element}}
+  {{@event}}
+  {{@viewModel}}
+  {{@arguments}}
+  {{@scope}}
+  {{%context}}
+  {{@context}}
 </p>

--- a/test/fixtures/version-4/can-stache/scope-output.stache
+++ b/test/fixtures/version-4/can-stache/scope-output.stache
@@ -5,6 +5,16 @@
   {{scope.event}}
   {{scope.viewModel}}
   {{scope.arguments}}
+  {{scope.scope}}
+  {{scope.index}}
+  {{scope.key}}
+  {{scope.element}}
+  {{scope.event}}
+  {{scope.viewModel}}
+  {{scope.arguments}}
+  {{scope.scope}}
+  {{this}}
+  {{this}}
 </p>
 
 <p>
@@ -14,4 +24,14 @@
   {{scope.event}}
   {{scope.viewModel}}
   {{scope.arguments}}
+  {{scope.scope}}
+  {{scope.index}}
+  {{scope.key}}
+  {{scope.element}}
+  {{scope.event}}
+  {{scope.viewModel}}
+  {{scope.arguments}}
+  {{scope.scope}}
+  {{this}}
+  {{this}}
 </p>


### PR DESCRIPTION
After this change:

`<custom-component prop="{H1}" />` => `<custom-component prop:from="H1" />` or `<custom-component vm:prop:from="H1" />`
`<input can-value="H2">` => `<input value:bind="H2">` or `<input el:value:bind="H2">`
`<input can-click="H3">` = `<input on:click="H3">` or `<input on:el:click="H3">`

...depending on whether explicit bindings are enabled.  "can-" events and value bindings are assumed to always be bound to the element and not a VM.